### PR TITLE
Use jemalloc

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Run tests
         run: zig build test --summary all
 
-      - run: apt-get update && apt-get install -y libjemalloc-dev
+      - run: sudo apt-get update && sudo apt-get install -y libjemalloc-dev
 
       - name: Build release binary
         run: zig build --release=fast --summary all

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,6 +30,8 @@ jobs:
       - name: Run tests
         run: zig build test --summary all
 
+      - run: apt-get update && apt-get install -y libjemalloc-dev
+
       - name: Build release binary
         run: zig build --release=fast --summary all
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:24.04
 
-RUN apt-get update && apt-get install -y glibc-tools
+RUN apt-get update && apt-get install -y glibc-tools libjemalloc2
 
 RUN useradd -m -s /bin/bash -u 6081 acoustid
 

--- a/build.zig
+++ b/build.zig
@@ -44,6 +44,7 @@ pub fn build(b: *std.Build) void {
 
     if (optimize == .ReleaseFast) {
         main_exe.linkLibC();
+        main_exe.linkSystemLibrary("jemalloc");
     }
     main_exe.root_module.addImport("httpz", httpz.module("httpz"));
     main_exe.root_module.addImport("metrics", metrics.module("metrics"));

--- a/src/jemalloc.zig
+++ b/src/jemalloc.zig
@@ -1,0 +1,49 @@
+const std = @import("std");
+const Allocator = std.mem.Allocator;
+const c = @cImport({
+    @cInclude("jemalloc/jemalloc.h");
+});
+
+pub const allocator = Allocator{
+    .ptr = undefined,
+    .vtable = &.{
+        .alloc = alloc,
+        .resize = resize,
+        .free = free,
+    },
+};
+
+fn alloc(_: *anyopaque, n: usize, log2_align: u8, return_address: usize) ?[*]u8 {
+    _ = return_address;
+
+    const alignment = @as(usize, 1) << @as(Allocator.Log2Align, @intCast(log2_align));
+    const ptr = c.je_aligned_alloc(alignment, n) orelse return null;
+    return @ptrCast(ptr);
+}
+
+fn resize(
+    _: *anyopaque,
+    buf: []u8,
+    log2_buf_align: u8,
+    new_len: usize,
+    return_address: usize,
+) bool {
+    _ = log2_buf_align;
+    _ = return_address;
+
+    if (new_len <= buf.len)
+        return true;
+
+    return new_len <= c.je_malloc_usable_size(buf.ptr);
+}
+
+fn free(_: *anyopaque, buf: []u8, log2_buf_align: u8, return_address: usize) void {
+    _ = log2_buf_align;
+    _ = return_address;
+    c.je_free(buf.ptr);
+}
+
+test "basic" {
+    const buf = try allocator.alloc(u8, 256);
+    defer allocator.free(buf);
+}

--- a/src/main.zig
+++ b/src/main.zig
@@ -7,6 +7,7 @@ const Scheduler = @import("utils/Scheduler.zig");
 const MultiIndex = @import("MultiIndex.zig");
 const server = @import("server.zig");
 const metrics = @import("metrics.zig");
+const jemalloc = @import("jemalloc.zig");
 
 pub const std_options = .{
     .log_level = .debug,
@@ -41,7 +42,7 @@ pub fn main() !void {
     var gpa: std.heap.GeneralPurposeAllocator(.{}) = .{};
     defer _ = gpa.deinit();
 
-    const allocator = if (builtin.mode == .ReleaseFast and !builtin.is_test) std.heap.c_allocator else gpa.allocator();
+    const allocator = if (builtin.mode == .ReleaseFast and !builtin.is_test) jemalloc.allocator else gpa.allocator();
 
     var args = try zul.CommandLineArgs.parse(allocator);
     defer args.deinit();


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a custom memory allocator using the jemalloc library.
	- Updated memory allocation strategy to utilize the new allocator in optimized builds.

- **Chores**
	- Enhanced environment setup by installing `libjemalloc-dev` and `libjemalloc2` packages.

- **Bug Fixes**
	- Improved memory management optimizations in the build process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->