### PR TITLE
perf(filefmt): Dynamically set mmap parameters based on the target platform

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /zig-out
 /.zig-cache
 __pycache__
+.idea

--- a/src/filefmt.zig
+++ b/src/filefmt.zig
@@ -390,10 +390,8 @@ pub fn readSegmentFile(dir: fs.Dir, info: SegmentInfo, segment: *FileSegment) !v
 
     const file_size = try file.getEndPos();
 
-    const mmap_flags: std.c.MAP = .{
-        .TYPE = .PRIVATE,
-    };
-    if (builtin.os.tag == .emscripten) {
+    const mmap_flags: std.c.MAP = .{ .TYPE = .PRIVATE };
+    if (builtin.os.tag == .linux or builtin.os.tag == .emscripten) {
         mmap_flags |= .{ .POPULATE = true };
     }
 

--- a/src/filefmt.zig
+++ b/src/filefmt.zig
@@ -1,4 +1,5 @@
 const std = @import("std");
+const builtin = @import("builtin");
 const testing = std.testing;
 const assert = std.debug.assert;
 const math = std.math;
@@ -389,11 +390,18 @@ pub fn readSegmentFile(dir: fs.Dir, info: SegmentInfo, segment: *FileSegment) !v
 
     const file_size = try file.getEndPos();
 
+    const mmap_flags: std.c.MAP = .{
+        .TYPE = .PRIVATE,
+    };
+    if (builtin.os.tag == .emscripten) {
+        mmap_flags |= .{ .POPULATE = true };
+    }
+
     var raw_data = try std.posix.mmap(
         null,
         file_size,
         std.posix.PROT.READ,
-        .{ .TYPE = .PRIVATE, .POPULATE = true },
+        mmap_flags,
         file.handle,
         0,
     );

--- a/src/filefmt.zig
+++ b/src/filefmt.zig
@@ -391,7 +391,7 @@ pub fn readSegmentFile(dir: fs.Dir, info: SegmentInfo, segment: *FileSegment) !v
     const file_size = try file.getEndPos();
 
     const mmap_flags: std.c.MAP = .{ .TYPE = .PRIVATE };
-    if (builtin.os.tag == .linux or builtin.os.tag == .emscripten) {
+    if (@hasField(std.c.MAP, "POPULATE")) {
         mmap_flags |= .{ .POPULATE = true };
     }
 

--- a/src/filefmt.zig
+++ b/src/filefmt.zig
@@ -390,9 +390,9 @@ pub fn readSegmentFile(dir: fs.Dir, info: SegmentInfo, segment: *FileSegment) !v
 
     const file_size = try file.getEndPos();
 
-    const mmap_flags: std.c.MAP = .{ .TYPE = .PRIVATE };
+    var mmap_flags: std.c.MAP = .{ .TYPE = .PRIVATE };
     if (@hasField(std.c.MAP, "POPULATE")) {
-        mmap_flags |= .{ .POPULATE = true };
+        mmap_flags.POPULATE = true;
     }
 
     var raw_data = try std.posix.mmap(


### PR DESCRIPTION
Not able to build on Macos directly due to the mmap parameters error, the `POPULATE` is only available on emscripten target.


chore: Add .idea directory to .gitignore