### PR TITLE
fix: correct timeout calculation in waitForReady

### DIFF
--- a/src/Index.zig
+++ b/src/Index.zig
@@ -373,7 +373,7 @@ fn maybeScheduleCheckpoint(self: *Self) void {
 }
 
 pub fn waitForReady(self: *Self, timeout_ms: u32) !void {
-    try self.is_ready.timedWait(timeout_ms * std.time.us_per_ms);
+    try self.is_ready.timedWait(@as(u64, timeout_ms) * std.time.ns_per_ms);
 }
 
 pub fn checkReady(self: *Self) !void {


### PR DESCRIPTION
The waitForReady function was incorrectly calculating the timeout by multiplying milliseconds by std.time.us_per_ms instead of std.time.ns_per_ms, causing timedWait to receive microseconds instead of nanoseconds. This led to immediate timeout errors. Also added u64 cast to prevent integer overflow for large timeout values.