### PR TITLE
Add timeout to legacy proxy read operations

### DIFF
--- a/legacy-proxy/proxy.py
+++ b/legacy-proxy/proxy.py
@@ -153,7 +153,11 @@ class Server:
 
             while True:
                 try:
-                    line = await reader.readuntil(b"\n")
+                    line = await asyncio.wait_for(reader.readuntil(b"\n"), timeout=30.0)
+                except asyncio.TimeoutError:
+                    writer.write(b"ERR timeout\r\n")
+                    await writer.drain()
+                    return
                 except asyncio.exceptions.IncompleteReadError:
                     return
 


### PR DESCRIPTION
## Summary

- Add 30-second timeout to `readuntil()` calls in legacy proxy using `asyncio.wait_for()`
- Properly handle timeout errors by sending error message and closing connection
- Prevents DoS attacks from clients that send partial data or connect but don't send complete commands
- Maintains proper resource cleanup via existing finally block

## Problem

The legacy proxy was vulnerable to hanging connections when clients connected but didn't send complete commands or sent partial data. This could lead to resource exhaustion and potential DoS attacks.

## Solution

Added timeout handling to the main read loop in `handle_connection()` method:
- Wrapped `reader.readuntil(b"\n")` with `asyncio.wait_for(timeout=30.0)`
- Added proper timeout error handling that sends "ERR timeout" and closes the connection
- Preserves existing resource cleanup via the finally block

## Test plan

- Test with legitimate clients that send complete commands quickly
- Test with slow clients that take longer than 30 seconds to send data
- Test with malicious clients that connect but send no data or partial data
- Verify connections are properly closed after timeout
- Verify error messages are correctly sent to clients