### PR TITLE
Simplify block format from unique hashes+counts to duplicate hashes

### DIFF
--- a/src/block.zig
+++ b/src/block.zig
@@ -130,8 +130,9 @@ pub const BlockReader = struct {
             self.block_data.?[offset..],
             &self.hashes,
             .variant0124,
+            .delta,
+            header.min_hash,
         );
-        streamvbyte.svbDeltaDecodeInPlace(self.hashes[0..header.num_items], header.min_hash);
         self.hashes_loaded = true;
     }
     /// Load and cache docids if not already loaded

--- a/src/block.zig
+++ b/src/block.zig
@@ -88,7 +88,7 @@ pub const BlockReader = struct {
         self.hashes_loaded = false;
         self.docids_loaded = false;
 
-        // If full is true, decode all hashes and docids immediately
+        // If lazy is false, decode all hashes and docids immediately
         if (!lazy) {
             self.ensureHashesLoaded();
             self.ensureDocidsLoaded();

--- a/src/block.zig
+++ b/src/block.zig
@@ -129,7 +129,7 @@ pub const BlockReader = struct {
             header.num_items,
             self.block_data.?[offset..],
             &self.hashes,
-            .variant1234,
+            .variant0124,
         );
         streamvbyte.svbDeltaDecodeInPlace(self.hashes[0..header.num_items], header.min_hash);
         self.hashes_loaded = true;
@@ -454,7 +454,7 @@ pub const BlockEncoder = struct {
         }
 
         // Calculate sizes for this chunk
-        const encoded_hashes_size = streamvbyte.svbEncodeQuad1234(
+        const encoded_hashes_size = streamvbyte.svbEncodeQuad0124(
             chunk_hashes,
             self.out_hashes.unusedCapacitySlice(),
             &self.out_hashes_control.buffer[self.out_hashes_control.len],

--- a/src/filefmt.zig
+++ b/src/filefmt.zig
@@ -310,7 +310,7 @@ pub fn readSegmentFile(dir: fs.Dir, info: SegmentInfo, segment: *FileSegment) !v
         const block_data = raw_data[ptr .. ptr + block_size];
         ptr += block_size;
         const block_header = decodeBlockHeader(block_data);
-        if (block_header.num_hashes == 0) {
+        if (block_header.num_items == 0) {
             break;
         }
         segment.index.appendAssumeCapacity(block_header.max_hash);


### PR DESCRIPTION
## Summary

Replace complex hybrid format with simpler approach based on production data showing 61 unique hashes vs 100 items per block on average.

## Changes

- Remove `num_hashes` and `counts_offset` from BlockHeader 
- Store all hashes including duplicates with delta encoding
- Use `std.sort.equalRange` for efficient hash range lookups
- Maintain docid delta encoding with hash boundary resets
- Simplify BlockEncoder by removing complex buffering logic
- Update BlockReader to handle 1:1 hash-to-docid mapping

## Test plan

- [x] All unit tests pass
- [x] Integration tests pass
- [x] Block encoding/decoding works correctly
- [x] Hash range queries function properly

This eliminates the overhead of storing counts for sparse hash distributions while maintaining compression efficiency through proper delta encoding.