### PR TITLE
Refactor index attributes to metadata with string values

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ HEAD /:indexname
 
 #### Get index information
 
-Returns detailed information about an index including version, segment count, document count, and attributes.
+Returns detailed information about an index including version, metadata, and statistics.
 
 ```http
 GET /:indexname
@@ -55,11 +55,15 @@ GET /:indexname
 ```json
 {
   "version": 1,
-  "segments": 2,
-  "docs": 1000,
-  "attributes": {
-    "min_document_id": 1,
-    "max_document_id": 999
+  "metadata": {
+    "key1": "value1",
+    "key2": "value2"
+  },
+  "stats": {
+    "min_doc_id": 1,
+    "max_doc_id": 999,
+    "num_segments": 2,
+    "num_docs": 1000
   }
 }
 ```
@@ -110,6 +114,14 @@ GET /:indexname/_segments
 }
 ```
 
+#### Create index snapshot
+
+Creates a downloadable tar archive containing complete index data for backup.
+
+```http
+GET /:indexname/_snapshot
+```
+
 ### Fingerprint Operations
 
 #### Bulk update operations
@@ -127,9 +139,17 @@ POST /:indexname/_update
     {"insert": {"id": 12345, "hashes": [100, 200, 300, 400, 500]}},
     {"insert": {"id": 67890, "hashes": [150, 250, 350]}},
     {"delete": {"id": 11111}}
-  ]
+  ],
+  "metadata": {
+    "key1": "value1",
+    "key2": "value2"
+  }
 }
 ```
+
+**Parameters:**
+- `changes` (required): Array of insert/delete operations to perform
+- `metadata` (optional): Key-value pairs of string metadata to associate with the index
 
 **Response:** Empty JSON object `{}`
 

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -17,8 +17,8 @@
             .hash = "122061f30077ef518dd435d397598ab3c45daa3d2c25e6b45383fb94d0bd2c3af1af",
         },
         .msgpack = .{
-            .url = "git+https://github.com/lalinsky/msgpack.zig?ref=main#501eb317ab8af8c274db9ae0782306399d7ca38d",
-            .hash = "msgpack-0.2.0-ZOu9PE-pAQDewD3lwb3jZpwBbrosWmHdZE_yTuXK5Rqe",
+            .url = "git+https://github.com/lalinsky/msgpack.zig?ref=v0.3.0#9b6c28d2924c6bdd4dcf6a71bb25c8a8e246c589",
+            .hash = "msgpack-0.3.0-ZOu9PE-pAQAVlR3s1gMD2xxG4JbVZfkWlYc9wTln7r0h",
         },
     },
     .paths = .{

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -17,8 +17,8 @@
             .hash = "122061f30077ef518dd435d397598ab3c45daa3d2c25e6b45383fb94d0bd2c3af1af",
         },
         .msgpack = .{
-            .url = "git+https://github.com/lalinsky/msgpack.zig?ref=v0.2.0#964ed489cf663fd3d7b79fe328300a71d3ab12d5",
-            .hash = "msgpack-0.1.0-ZOu9PHimAQCfeM27BhUPC1NY6ZXjMlL2_ZEkjWRDldrT",
+            .url = "git+https://github.com/lalinsky/msgpack.zig?ref=main#501eb317ab8af8c274db9ae0782306399d7ca38d",
+            .hash = "msgpack-0.2.0-ZOu9PE-pAQDewD3lwb3jZpwBbrosWmHdZE_yTuXK5Rqe",
         },
     },
     .paths = .{

--- a/src/FileSegment.zig
+++ b/src/FileSegment.zig
@@ -48,7 +48,7 @@ pub fn init(allocator: std.mem.Allocator, options: Options) Self {
         .allocator = allocator,
         .dir = options.dir,
         .blocks = undefined,
-        .metadata = Metadata.init(allocator),
+        .metadata = Metadata.initOwned(allocator),
     };
 }
 
@@ -222,7 +222,12 @@ test "build and reader with duplicate hashes" {
         .{ .insert = .{ .id = 3, .hashes = &[_]u32{100} } },
     };
 
-    try source.build(&changes);
+    var metadata = Metadata.initOwned(std.testing.allocator);
+    defer metadata.deinit();
+
+    try metadata.set("foo", "bar");
+
+    try source.build(&changes, metadata);
 
     var source_reader = source.reader();
     defer source_reader.close();

--- a/src/FileSegment.zig
+++ b/src/FileSegment.zig
@@ -27,7 +27,7 @@ allocator: std.mem.Allocator,
 dir: std.fs.Dir,
 info: SegmentInfo = .{},
 status: SegmentStatus = .{},
-metadata: std.StringHashMapUnmanaged(?[]const u8) = .{},
+metadata: std.StringHashMapUnmanaged([]const u8) = .{},
 docs: std.AutoHashMapUnmanaged(u32, bool) = .{},
 min_doc_id: u32 = 0,
 max_doc_id: u32 = 0,
@@ -54,9 +54,7 @@ pub fn deinit(self: *Self, delete_file: KeepOrDelete) void {
     var iter = self.metadata.iterator();
     while (iter.next()) |e| {
         self.allocator.free(e.key_ptr.*);
-        if (e.value_ptr.*) |value| {
-            self.allocator.free(value);
-        }
+        self.allocator.free(e.value_ptr.*);
     }
     self.metadata.deinit(self.allocator);
     self.docs.deinit(self.allocator);

--- a/src/FileSegment.zig
+++ b/src/FileSegment.zig
@@ -27,7 +27,7 @@ allocator: std.mem.Allocator,
 dir: std.fs.Dir,
 info: SegmentInfo = .{},
 status: SegmentStatus = .{},
-attributes: std.StringHashMapUnmanaged(u64) = .{},
+metadata: std.StringHashMapUnmanaged(?[]const u8) = .{},
 docs: std.AutoHashMapUnmanaged(u32, bool) = .{},
 min_doc_id: u32 = 0,
 max_doc_id: u32 = 0,
@@ -51,11 +51,14 @@ pub fn init(allocator: std.mem.Allocator, options: Options) Self {
 }
 
 pub fn deinit(self: *Self, delete_file: KeepOrDelete) void {
-    var iter = self.attributes.iterator();
+    var iter = self.metadata.iterator();
     while (iter.next()) |e| {
         self.allocator.free(e.key_ptr.*);
+        if (e.value_ptr.*) |value| {
+            self.allocator.free(value);
+        }
     }
-    self.attributes.deinit(self.allocator);
+    self.metadata.deinit(self.allocator);
     self.docs.deinit(self.allocator);
 
     if (self.mmaped_data) |data| {

--- a/src/Index.zig
+++ b/src/Index.zig
@@ -8,6 +8,7 @@ const Deadline = @import("utils/Deadline.zig");
 const Scheduler = @import("utils/Scheduler.zig");
 const WaitGroup = @import("utils/WaitGroup.zig");
 const Change = @import("change.zig").Change;
+const Metadata = @import("change.zig").Metadata;
 const SearchResult = @import("common.zig").SearchResult;
 const SearchResults = @import("common.zig").SearchResults;
 const SegmentInfo = @import("segment.zig").SegmentInfo;
@@ -518,21 +519,21 @@ pub fn checkReady(self: *Self) !void {
     }
 }
 
-pub fn update(self: *Self, changes: []const Change) !void {
+pub fn update(self: *Self, changes: []const Change, metadata: ?Metadata) !void {
     try self.checkReady();
-    try self.updateInternal(changes, null);
+    try self.updateInternal(changes, metadata, null);
 }
 
-fn updateInternal(self: *Self, changes: []const Change, commit_id: ?u64) !void {
+fn updateInternal(self: *Self, changes: []const Change, metadata: ?Metadata, commit_id: ?u64) !void {
     var target = try MemorySegmentList.createSegment(self.allocator, .{});
     defer MemorySegmentList.destroySegment(self.allocator, &target);
 
-    try target.value.build(changes);
+    try target.value.build(changes, metadata);
 
     var upd = try self.memory_segments.beginUpdate(self.allocator);
     defer self.memory_segments.cleanupAfterUpdate(self.allocator, &upd);
 
-    target.value.info.version = commit_id orelse try self.oplog.write(changes);
+    target.value.info.version = commit_id orelse try self.oplog.write(changes, metadata);
 
     defer self.updateDocsMetrics();
 

--- a/src/IndexReader.zig
+++ b/src/IndexReader.zig
@@ -133,7 +133,7 @@ pub fn getMetadata(self: *Self, allocator: std.mem.Allocator) !std.StringHashMap
 }
 
 pub fn getMetadataWrapper(self: *Self, allocator: std.mem.Allocator) !Metadata {
-    var metadata = Metadata.init(allocator);
+    var metadata = Metadata.initBorrowed(allocator);
     errdefer metadata.deinit();
 
     inline for (segment_lists) |n| {
@@ -142,7 +142,7 @@ pub fn getMetadataWrapper(self: *Self, allocator: std.mem.Allocator) !Metadata {
             var iter = node.value.metadata.iterator();
             while (iter.next()) |entry| {
                 if (metadata.get(entry.key) == null) {
-                    try metadata.setBorrowed(entry.key, entry.value);
+                    try metadata.set(entry.key, entry.value);
                 }
             }
         }

--- a/src/IndexReader.zig
+++ b/src/IndexReader.zig
@@ -132,15 +132,29 @@ pub fn getMetadata(self: *Self, allocator: std.mem.Allocator) !std.StringHashMap
 }
 
 pub const Stats = struct {
-    min_doc_id: ?u32,
-    max_doc_id: ?u32,
+    min_doc_id: u32,
+    max_doc_id: u32,
+    num_segments: usize,
+    num_docs: u32,
+
+    pub fn msgpackWrite(self: Stats, packer: anytype) !void {
+        try packer.writeMapHeader(4);
+        try packer.write("min");
+        try packer.write(self.min_doc_id);
+        try packer.write("max");
+        try packer.write(self.max_doc_id);
+        try packer.write("s");
+        try packer.write(self.num_segments);
+        try packer.write("d");
+        try packer.write(self.num_docs);
+    }
 };
 
 pub fn getStats(self: *Self) Stats {
-    const min_doc_id = self.getMinDocId();
-    const max_doc_id = self.getMaxDocId();
     return Stats{
-        .min_doc_id = if (min_doc_id == 0) null else min_doc_id,
-        .max_doc_id = if (max_doc_id == 0) null else max_doc_id,
+        .min_doc_id = self.getMinDocId(),
+        .max_doc_id = self.getMaxDocId(),
+        .num_segments = self.getNumSegments(),
+        .num_docs = self.getNumDocs(),
     };
 }

--- a/src/MemorySegment.zig
+++ b/src/MemorySegment.zig
@@ -133,7 +133,7 @@ pub fn merge(self: *Self, merger: *SegmentMerger(Self)) !void {
     self.info = merger.segment.info;
 
     self.metadata.deinit();
-    self.metadata = merger.segment.metadata;
+    self.metadata = merger.segment.metadata.move();
 
     self.docs.deinit(self.allocator);
     self.docs = merger.segment.docs.move();

--- a/src/MemorySegment.zig
+++ b/src/MemorySegment.zig
@@ -119,7 +119,7 @@ pub fn build(self: *Self, changes: []const Change) !void {
                 }
             },
             .set_metadata => |op| {
-                try self.metadata.setOwned(op.name, op.value);
+                try self.metadata.set(op.name, op.value);
             },
         }
     }

--- a/src/Metadata.zig
+++ b/src/Metadata.zig
@@ -1,0 +1,237 @@
+const std = @import("std");
+
+const Self = @This();
+
+/// Ownership mode for keys and values
+pub const Ownership = enum {
+    owned,     // Keys/values are allocated and need to be freed
+    borrowed,  // Keys/values are borrowed references, don't free
+};
+
+/// Internal entry to track ownership per key-value pair
+const Entry = struct {
+    key: []const u8,
+    value: []const u8,
+    key_owned: bool,
+    value_owned: bool,
+};
+
+allocator: std.mem.Allocator,
+entries: std.StringHashMapUnmanaged(Entry),
+
+/// Initialize empty metadata with given allocator
+pub fn init(allocator: std.mem.Allocator) Self {
+    return Self{
+        .allocator = allocator,
+        .entries = .{},
+    };
+}
+
+/// Deinitialize and free all owned keys and values
+pub fn deinit(self: *Self) void {
+    var iter = self.entries.iterator();
+    while (iter.next()) |entry| {
+        if (entry.value_ptr.key_owned) {
+            self.allocator.free(entry.value_ptr.key);
+        }
+        if (entry.value_ptr.value_owned) {
+            self.allocator.free(entry.value_ptr.value);
+        }
+    }
+    self.entries.deinit(self.allocator);
+}
+
+/// Set a key-value pair with specified ownership
+pub fn set(self: *Self, key: []const u8, value: []const u8, key_ownership: Ownership, value_ownership: Ownership) !void {
+    const result = try self.entries.getOrPut(self.allocator, key);
+    
+    // If updating existing entry, free old values if they were owned
+    if (result.found_existing) {
+        if (result.value_ptr.key_owned) {
+            self.allocator.free(result.value_ptr.key);
+        }
+        if (result.value_ptr.value_owned) {
+            self.allocator.free(result.value_ptr.value);
+        }
+    }
+    
+    // Set up the new entry
+    const key_owned = key_ownership == .owned;
+    const value_owned = value_ownership == .owned;
+    
+    result.value_ptr.* = Entry{
+        .key = if (key_owned) try self.allocator.dupe(u8, key) else key,
+        .value = if (value_owned) try self.allocator.dupe(u8, value) else value,
+        .key_owned = key_owned,
+        .value_owned = value_owned,
+    };
+    
+    // Update the hashmap's key pointer to our stored key
+    result.key_ptr.* = result.value_ptr.key;
+}
+
+/// Set a key-value pair, taking ownership of both (convenience method)
+pub fn setOwned(self: *Self, key: []const u8, value: []const u8) !void {
+    try self.set(key, value, .owned, .owned);
+}
+
+/// Set a key-value pair without taking ownership (convenience method)
+pub fn setBorrowed(self: *Self, key: []const u8, value: []const u8) !void {
+    try self.set(key, value, .borrowed, .borrowed);
+}
+
+/// Get value for a key, returns null if not found
+pub fn get(self: Self, key: []const u8) ?[]const u8 {
+    const entry = self.entries.get(key);
+    return if (entry) |e| e.value else null;
+}
+
+/// Remove a key-value pair, freeing owned memory
+pub fn remove(self: *Self, key: []const u8) bool {
+    const kv = self.entries.fetchRemove(key) orelse return false;
+    if (kv.value.key_owned) {
+        self.allocator.free(kv.value.key);
+    }
+    if (kv.value.value_owned) {
+        self.allocator.free(kv.value.value);
+    }
+    return true;
+}
+
+/// Get count of entries
+pub fn count(self: Self) usize {
+    return self.entries.count();
+}
+
+/// Iterator for key-value pairs
+pub const Iterator = struct {
+    inner: std.StringHashMapUnmanaged(Entry).Iterator,
+    
+    pub fn next(self: *Iterator) ?struct { key: []const u8, value: []const u8 } {
+        const entry = self.inner.next() orelse return null;
+        return .{ .key = entry.value_ptr.key, .value = entry.value_ptr.value };
+    }
+};
+
+/// Get iterator over key-value pairs
+pub fn iterator(self: Self) Iterator {
+    return Iterator{ .inner = self.entries.iterator() };
+}
+
+/// Ensure capacity for a given number of entries
+pub fn ensureTotalCapacity(self: *Self, capacity: u32) !void {
+    try self.entries.ensureTotalCapacity(self.allocator, capacity);
+}
+
+/// Copy all entries from another metadata instance, taking ownership
+pub fn copyFrom(self: *Self, other: Self) !void {
+    try self.ensureTotalCapacity(@intCast(other.count()));
+    var iter = other.iterator();
+    while (iter.next()) |entry| {
+        try self.setOwned(entry.key, entry.value);
+    }
+}
+
+/// Merge entries from another metadata instance, with this instance taking precedence for conflicts
+pub fn mergeFrom(self: *Self, other: Self) !void {
+    var iter = other.iterator();
+    while (iter.next()) |entry| {
+        if (self.get(entry.key) == null) {
+            try self.setOwned(entry.key, entry.value);
+        }
+    }
+}
+
+/// JSON serialization
+pub fn jsonStringify(self: Self, jws: anytype) !void {
+    try jws.beginObject();
+    var iter = self.iterator();
+    while (iter.next()) |entry| {
+        try jws.objectField(entry.key);
+        try jws.write(entry.value);
+    }
+    try jws.endObject();
+}
+
+/// MessagePack serialization
+pub fn msgpackWrite(self: Self, packer: anytype) !void {
+    try packer.writeMapHeader(self.count());
+    var iter = self.iterator();
+    while (iter.next()) |entry| {
+        try packer.write(entry.key);
+        try packer.write(entry.value);
+    }
+}
+
+/// Create metadata from unmanaged hashmap, taking ownership of all strings
+pub fn fromUnmanagedOwned(allocator: std.mem.Allocator, hashmap: std.StringHashMapUnmanaged([]const u8)) !Self {
+    var metadata = init(allocator);
+    errdefer metadata.deinit();
+    
+    try metadata.ensureTotalCapacity(@intCast(hashmap.count()));
+    var iter = hashmap.iterator();
+    while (iter.next()) |entry| {
+        try metadata.setOwned(entry.key_ptr.*, entry.value_ptr.*);
+    }
+    
+    return metadata;
+}
+
+/// Create metadata from unmanaged hashmap, borrowing all strings
+pub fn fromUnmanagedBorrowed(allocator: std.mem.Allocator, hashmap: std.StringHashMapUnmanaged([]const u8)) !Self {
+    var metadata = init(allocator);
+    errdefer metadata.deinit();
+    
+    try metadata.ensureTotalCapacity(@intCast(hashmap.count()));
+    var iter = hashmap.iterator();
+    while (iter.next()) |entry| {
+        try metadata.setBorrowed(entry.key_ptr.*, entry.value_ptr.*);
+    }
+    
+    return metadata;
+}
+
+/// Convert to unmanaged hashmap (returns borrowed references to internal strings)
+pub fn toUnmanaged(self: Self, allocator: std.mem.Allocator) !std.StringHashMapUnmanaged([]const u8) {
+    var hashmap: std.StringHashMapUnmanaged([]const u8) = .{};
+    errdefer hashmap.deinit(allocator);
+    
+    try hashmap.ensureTotalCapacity(allocator, @intCast(self.count()));
+    var iter = self.iterator();
+    while (iter.next()) |entry| {
+        hashmap.putAssumeCapacity(entry.key, entry.value);
+    }
+    
+    return hashmap;
+}
+
+/// Clear all entries, retaining capacity
+pub fn clearRetainingCapacity(self: *Self) void {
+    var iter = self.entries.iterator();
+    while (iter.next()) |entry| {
+        if (entry.value_ptr.key_owned) {
+            self.allocator.free(entry.value_ptr.key);
+        }
+        if (entry.value_ptr.value_owned) {
+            self.allocator.free(entry.value_ptr.value);
+        }
+    }
+    self.entries.clearRetainingCapacity();
+}
+
+/// Load from msgpack into this metadata instance, taking ownership of all strings
+pub fn loadFromMsgpackOwned(self: *Self, reader: anytype, allocator: std.mem.Allocator) !void {
+    // First load into a temporary unmanaged map
+    var temp_map: std.StringHashMapUnmanaged([]const u8) = .{};
+    defer temp_map.deinit(allocator);
+    
+    const msgpack = @import("msgpack");
+    try msgpack.unpackMapInto(reader, allocator, &temp_map);
+    
+    // Now transfer to our metadata with ownership
+    try self.ensureTotalCapacity(@intCast(temp_map.count()));
+    var iter = temp_map.iterator();
+    while (iter.next()) |entry| {
+        try self.setOwned(entry.key_ptr.*, entry.value_ptr.*);
+    }
+}

--- a/src/Metadata.zig
+++ b/src/Metadata.zig
@@ -144,48 +144,6 @@ pub fn msgpackRead(unpacker: anytype) !Self {
     return self;
 }
 
-/// Create metadata from unmanaged hashmap, taking ownership of all strings
-pub fn fromUnmanagedOwned(allocator: std.mem.Allocator, hashmap: std.StringHashMapUnmanaged([]const u8)) !Self {
-    var metadata = initOwned(allocator);
-    errdefer metadata.deinit();
-
-    try metadata.ensureTotalCapacity(@intCast(hashmap.count()));
-    var iter = hashmap.iterator();
-    while (iter.next()) |entry| {
-        try metadata.set(entry.key_ptr.*, entry.value_ptr.*);
-    }
-
-    return metadata;
-}
-
-/// Create metadata from unmanaged hashmap, borrowing all strings
-pub fn fromUnmanagedBorrowed(allocator: std.mem.Allocator, hashmap: std.StringHashMapUnmanaged([]const u8)) !Self {
-    var metadata = initBorrowed(allocator);
-    errdefer metadata.deinit();
-
-    try metadata.ensureTotalCapacity(@intCast(hashmap.count()));
-    var iter = hashmap.iterator();
-    while (iter.next()) |entry| {
-        try metadata.set(entry.key_ptr.*, entry.value_ptr.*);
-    }
-
-    return metadata;
-}
-
-/// Convert to unmanaged hashmap (returns borrowed references to internal strings)
-pub fn toUnmanaged(self: Self, allocator: std.mem.Allocator) !std.StringHashMapUnmanaged([]const u8) {
-    var hashmap: std.StringHashMapUnmanaged([]const u8) = .{};
-    errdefer hashmap.deinit(allocator);
-
-    try hashmap.ensureTotalCapacity(allocator, @intCast(self.count()));
-    var iter = self.entries.iterator();
-    while (iter.next()) |entry| {
-        hashmap.putAssumeCapacity(entry.key_ptr.*, entry.value_ptr.*);
-    }
-
-    return hashmap;
-}
-
 /// Clear all entries, retaining capacity
 pub fn clearRetainingCapacity(self: *Self) void {
     if (self.owned) {

--- a/src/Metadata.zig
+++ b/src/Metadata.zig
@@ -55,6 +55,8 @@ fn setOwned(self: *Self, key: []const u8, value: []const u8) !void {
     if (!result.found_existing) {
         errdefer self.entries.removeByPtr(result.key_ptr);
         result.key_ptr.* = try self.allocator.dupe(u8, key);
+    } else {
+        self.allocator.free(result.value_ptr.*);
     }
 
     result.value_ptr.* = owned_value;

--- a/src/Metadata.zig
+++ b/src/Metadata.zig
@@ -144,6 +144,14 @@ pub fn msgpackRead(unpacker: anytype) !Self {
     return self;
 }
 
+pub fn move(self: *Self) Self {
+    return .{
+        .allocator = self.allocator,
+        .owned = self.owned,
+        .entries = self.entries.move(),
+    };
+}
+
 /// Clear all entries, retaining capacity
 pub fn clearRetainingCapacity(self: *Self) void {
     if (self.owned) {

--- a/src/Metadata.zig
+++ b/src/Metadata.zig
@@ -113,9 +113,9 @@ pub fn jsonStringify(self: Self, jws: anytype) !void {
 /// JSON parsing
 pub fn jsonParse(allocator: std.mem.Allocator, source: anytype, options: std.json.ParseOptions) !Self {
     var parsed = try std.json.ArrayHashMap([]const u8).jsonParse(allocator, source, options);
-    errdefer parsed.deinit(allocator);
+    defer parsed.deinit(allocator);
 
-    var self = Self.initBorrowed(allocator);
+    var self = Self.initOwned(allocator);
     errdefer self.deinit();
 
     var iter = parsed.map.iterator();

--- a/src/change.zig
+++ b/src/change.zig
@@ -17,28 +17,21 @@ pub const Delete = struct {
     }
 };
 
-pub const SetMetadata = struct {
-    name: []const u8,
-    value: []const u8,
-
-    pub fn msgpackFormat() msgpack.StructFormat {
-        return .{ .as_map = .{ .key = .{ .field_name_prefix = 1 } } };
-    }
-};
-
 pub const Change = union(enum) {
     insert: Insert,
     delete: Delete,
-    set_metadata: SetMetadata,
 
     pub fn msgpackFormat() msgpack.UnionFormat {
         return .{ .as_map = .{ .key = .{ .field_name_prefix = 1 } } };
     }
 };
 
+pub const Metadata = @import("Metadata.zig");
+
 pub const Transaction = struct {
     id: u64,
     changes: []const Change,
+    metadata: ?Metadata,
 
     pub fn msgpackFormat() msgpack.StructFormat {
         return .{ .as_map = .{ .key = .{ .field_name_prefix = 1 } } };

--- a/src/change.zig
+++ b/src/change.zig
@@ -31,7 +31,7 @@ pub const Metadata = @import("Metadata.zig");
 pub const Transaction = struct {
     id: u64,
     changes: []const Change,
-    metadata: ?Metadata,
+    metadata: ?Metadata = null,
 
     pub fn msgpackFormat() msgpack.StructFormat {
         return .{ .as_map = .{ .key = .{ .field_name_prefix = 1 } } };

--- a/src/change.zig
+++ b/src/change.zig
@@ -19,7 +19,7 @@ pub const Delete = struct {
 
 pub const SetMetadata = struct {
     name: []const u8,
-    value: ?[]const u8,
+    value: []const u8,
 
     pub fn msgpackFormat() msgpack.StructFormat {
         return .{ .as_map = .{ .key = .{ .field_name_prefix = 1 } } };

--- a/src/change.zig
+++ b/src/change.zig
@@ -17,9 +17,9 @@ pub const Delete = struct {
     }
 };
 
-pub const SetAttribute = struct {
+pub const SetMetadata = struct {
     name: []const u8,
-    value: u64,
+    value: ?[]const u8,
 
     pub fn msgpackFormat() msgpack.StructFormat {
         return .{ .as_map = .{ .key = .{ .field_name_prefix = 1 } } };
@@ -29,7 +29,7 @@ pub const SetAttribute = struct {
 pub const Change = union(enum) {
     insert: Insert,
     delete: Delete,
-    set_attribute: SetAttribute,
+    set_metadata: SetMetadata,
 
     pub fn msgpackFormat() msgpack.UnionFormat {
         return .{ .as_map = .{ .key = .{ .field_name_prefix = 1 } } };

--- a/src/filefmt.zig
+++ b/src/filefmt.zig
@@ -1,6 +1,6 @@
 // Segment file format layout:
 // 1. Header - msgpack encoded segment metadata and configuration
-// 2. Metadata - msgpack encoded string to optional string mappings
+// 2. Metadata - msgpack encoded string to string mappings
 // 3. Documents - msgpack encoded document ID to boolean mappings
 // 4. Padding - zero bytes to align to block size boundary
 // 5. Blocks - fixed-size blocks containing the inverted index data

--- a/src/filefmt.zig
+++ b/src/filefmt.zig
@@ -294,7 +294,7 @@ pub fn readSegmentFile(dir: fs.Dir, info: SegmentInfo, segment: *FileSegment) !v
 
     segment.metadata.clearRetainingCapacity();
     if (header.has_metadata) {
-        try segment.metadata.loadFromMsgpackOwned(reader, segment.allocator);
+        try segment.metadata.loadFromMsgpack(reader, segment.allocator);
     }
 
     segment.min_doc_id = 0;

--- a/src/filefmt.zig
+++ b/src/filefmt.zig
@@ -201,7 +201,7 @@ pub fn writeSegmentFile(dir: std.fs.Dir, reader: anytype) !void {
     };
     try packer.write(header);
 
-    try packer.writeMap(segment.metadata);
+    try segment.metadata.msgpackWrite(packer);
     try packer.writeMap(segment.docs);
 
     try buffered_writer.flush();
@@ -294,7 +294,7 @@ pub fn readSegmentFile(dir: fs.Dir, info: SegmentInfo, segment: *FileSegment) !v
 
     segment.metadata.clearRetainingCapacity();
     if (header.has_metadata) {
-        try msgpack.unpackMapInto(reader, segment.allocator, &segment.metadata);
+        try segment.metadata.loadFromMsgpackOwned(reader, segment.allocator);
     }
 
     segment.min_doc_id = 0;

--- a/src/index_tests.zig
+++ b/src/index_tests.zig
@@ -49,7 +49,7 @@ test "index create, update and search" {
     try index.update(&[_]Change{.{ .insert = .{
         .id = 1,
         .hashes = generateRandomHashes(&hashes, 1),
-    } }});
+    } }}, null);
 
     {
         var collector = SearchResults.init(std.testing.allocator, .{});
@@ -90,7 +90,7 @@ test "index create, update, reopen and search" {
         try index.update(&[_]Change{.{ .insert = .{
             .id = 1,
             .hashes = generateRandomHashes(&hashes, 1),
-        } }});
+        } }}, null);
     }
 
     {
@@ -131,7 +131,7 @@ test "index many updates and inserts" {
         try index.update(&[_]Change{.{ .insert = .{
             .id = @as(u32, @intCast(i % 20)) + 1,
             .hashes = generateRandomHashes(&hashes, i),
-        } }});
+        } }}, null);
     }
 
     // Test 2: Batch inserts with larger scale
@@ -158,7 +158,7 @@ test "index many updates and inserts" {
 
         if (batch.items.len == batch_size or i == total_count) {
             try index.waitForReady(10000);
-            try index.update(batch.items);
+            try index.update(batch.items, null);
 
             // Clean up allocated hashes
             for (batch.items) |change| {
@@ -230,12 +230,12 @@ test "index, multiple fingerprints with the same hashes" {
     try index.update(&[_]Change{.{ .insert = .{
         .id = 1,
         .hashes = generateRandomHashes(&hashes, 1),
-    } }});
+    } }}, null);
 
     try index.update(&[_]Change{.{ .insert = .{
         .id = 2,
         .hashes = generateRandomHashes(&hashes, 1),
-    } }});
+    } }}, null);
 
     var collector = SearchResults.init(std.testing.allocator, .{});
     defer collector.deinit();

--- a/src/segment_builder_tool.zig
+++ b/src/segment_builder_tool.zig
@@ -13,21 +13,21 @@ pub const TextSegmentReader = struct {
 
     const SegmentData = struct {
         info: SegmentInfo,
-        attributes: std.StringHashMap(u64),
+        metadata: std.StringHashMap(?[]const u8),
         docs: std.AutoHashMap(u32, bool),
         min_doc_id: u32,
 
         pub fn init(allocator: std.mem.Allocator, info: SegmentInfo) SegmentData {
             return .{
                 .info = info,
-                .attributes = std.StringHashMap(u64).init(allocator),
+                .metadata = std.StringHashMap(?[]const u8).init(allocator),
                 .docs = std.AutoHashMap(u32, bool).init(allocator),
                 .min_doc_id = std.math.maxInt(u32),
             };
         }
 
         pub fn deinit(self: *SegmentData) void {
-            self.attributes.deinit();
+            self.metadata.deinit();
             self.docs.deinit();
         }
     };

--- a/src/segment_builder_tool.zig
+++ b/src/segment_builder_tool.zig
@@ -4,6 +4,7 @@ const builtin = @import("builtin");
 const filefmt = @import("filefmt.zig");
 const SegmentInfo = @import("segment.zig").SegmentInfo;
 const Item = @import("segment.zig").Item;
+const Metadata = @import("Metadata.zig");
 
 pub const TextSegmentReader = struct {
     allocator: std.mem.Allocator,
@@ -13,14 +14,14 @@ pub const TextSegmentReader = struct {
 
     const SegmentData = struct {
         info: SegmentInfo,
-        metadata: std.StringHashMap([]const u8),
+        metadata: Metadata,
         docs: std.AutoHashMap(u32, bool),
         min_doc_id: u32,
 
         pub fn init(allocator: std.mem.Allocator, info: SegmentInfo) SegmentData {
             return .{
                 .info = info,
-                .metadata = std.StringHashMap([]const u8).init(allocator),
+                .metadata = Metadata.init(allocator),
                 .docs = std.AutoHashMap(u32, bool).init(allocator),
                 .min_doc_id = std.math.maxInt(u32),
             };

--- a/src/segment_builder_tool.zig
+++ b/src/segment_builder_tool.zig
@@ -13,14 +13,14 @@ pub const TextSegmentReader = struct {
 
     const SegmentData = struct {
         info: SegmentInfo,
-        metadata: std.StringHashMap(?[]const u8),
+        metadata: std.StringHashMap([]const u8),
         docs: std.AutoHashMap(u32, bool),
         min_doc_id: u32,
 
         pub fn init(allocator: std.mem.Allocator, info: SegmentInfo) SegmentData {
             return .{
                 .info = info,
-                .metadata = std.StringHashMap(?[]const u8).init(allocator),
+                .metadata = std.StringHashMap([]const u8).init(allocator),
                 .docs = std.AutoHashMap(u32, bool).init(allocator),
                 .min_doc_id = std.math.maxInt(u32),
             };

--- a/src/segment_builder_tool.zig
+++ b/src/segment_builder_tool.zig
@@ -21,7 +21,7 @@ pub const TextSegmentReader = struct {
         pub fn init(allocator: std.mem.Allocator, info: SegmentInfo) SegmentData {
             return .{
                 .info = info,
-                .metadata = Metadata.init(allocator),
+                .metadata = Metadata.initOwned(allocator),
                 .docs = std.AutoHashMap(u32, bool).init(allocator),
                 .min_doc_id = std.math.maxInt(u32),
             };
@@ -49,7 +49,7 @@ pub const TextSegmentReader = struct {
 
         while (true) {
             line_buffer.clearRetainingCapacity();
-            
+
             stdin_reader.reader().readUntilDelimiterArrayList(&line_buffer, '\n', std.math.maxInt(usize)) catch |err| switch (err) {
                 error.EndOfStream => {
                     if (line_buffer.items.len == 0) break;

--- a/src/segment_merger.zig
+++ b/src/segment_merger.zig
@@ -7,7 +7,7 @@ const SharedPtr = @import("utils/shared_ptr.zig").SharedPtr;
 
 pub const MergedSegmentInfo = struct {
     info: SegmentInfo = .{},
-    metadata: std.StringHashMapUnmanaged(?[]const u8) = .{},
+    metadata: std.StringHashMapUnmanaged([]const u8) = .{},
     docs: std.AutoHashMapUnmanaged(u32, bool) = .{},
     min_doc_id: u32 = 0,
     max_doc_id: u32 = 0,
@@ -16,9 +16,7 @@ pub const MergedSegmentInfo = struct {
         var iter = self.metadata.iterator();
         while (iter.next()) |e| {
             allocator.free(e.key_ptr.*);
-            if (e.value_ptr.*) |value| {
-                allocator.free(value);
-            }
+            allocator.free(e.value_ptr.*);
         }
         self.metadata.deinit(allocator);
         self.docs.deinit(allocator);
@@ -115,11 +113,7 @@ pub fn SegmentMerger(comptime Segment: type) type {
                         errdefer self.segment.metadata.removeByPtr(result.key_ptr);
                         result.key_ptr.* = try self.allocator.dupe(u8, name);
                     }
-                    if (value) |v| {
-                        result.value_ptr.* = try self.allocator.dupe(u8, v);
-                    } else {
-                        result.value_ptr.* = null;
-                    }
+                    result.value_ptr.* = try self.allocator.dupe(u8, value);
                 }
             }
 

--- a/src/segment_merger.zig
+++ b/src/segment_merger.zig
@@ -61,7 +61,7 @@ pub fn SegmentMerger(comptime Segment: type) type {
                 .allocator = allocator,
                 .collection = collection,
                 .sources = try std.ArrayListUnmanaged(Source).initCapacity(allocator, num_sources),
-                .segment = .{ .metadata = Metadata.init(allocator) },
+                .segment = .{ .metadata = Metadata.initOwned(allocator) },
             };
         }
 
@@ -98,15 +98,8 @@ pub fn SegmentMerger(comptime Segment: type) type {
                 total_docs += source.reader.segment.docs.count();
             }
 
-            try self.segment.metadata.ensureTotalCapacity(total_attributes);
             for (sources) |*source| {
-                const segment = source.reader.segment;
-                var iter = segment.metadata.iterator();
-                while (iter.next()) |entry| {
-                    if (self.segment.metadata.get(entry.key) == null) {
-                        try self.segment.metadata.set(entry.key, entry.value);
-                    }
-                }
+                try self.segment.metadata.update(source.reader.segment.metadata);
             }
 
             try self.segment.docs.ensureTotalCapacity(self.allocator, total_docs);

--- a/src/segment_merger.zig
+++ b/src/segment_merger.zig
@@ -104,7 +104,7 @@ pub fn SegmentMerger(comptime Segment: type) type {
                 var iter = segment.metadata.iterator();
                 while (iter.next()) |entry| {
                     if (self.segment.metadata.get(entry.key) == null) {
-                        try self.segment.metadata.setOwned(entry.key, entry.value);
+                        try self.segment.metadata.set(entry.key, entry.value);
                     }
                 }
             }

--- a/src/server.zig
+++ b/src/server.zig
@@ -529,9 +529,7 @@ fn handleGetIndex(ctx: *Context, req: *httpz.Request, res: *httpz.Response) !voi
                 const unmanaged_metadata = try index_reader.getMetadata(req.arena);
                 var iter = unmanaged_metadata.iterator();
                 while (iter.next()) |entry| {
-                    if (entry.value_ptr.*) |value| {
-                        try managed_metadata.put(entry.key_ptr.*, value);
-                    }
+                    try managed_metadata.put(entry.key_ptr.*, entry.value_ptr.*);
                 }
                 break :blk managed_metadata;
             },

--- a/src/server.zig
+++ b/src/server.zig
@@ -480,19 +480,13 @@ const Metadata = struct {
 
 const GetIndexResponse = struct {
     version: u64,
-    segments: usize,
-    docs: usize,
     metadata: Metadata,
     stats: IndexReader.Stats,
 
     pub fn msgpackWrite(self: GetIndexResponse, packer: anytype) !void {
-        try packer.writeMapHeader(5);
+        try packer.writeMapHeader(3);
         try packer.write("v");
         try packer.write(self.version);
-        try packer.write("s");
-        try packer.write(self.segments);
-        try packer.write("d");
-        try packer.write(self.docs);
         try packer.write("m");
         try packer.write(self.metadata);
         try packer.write("st");
@@ -509,8 +503,6 @@ fn handleGetIndex(ctx: *Context, req: *httpz.Request, res: *httpz.Response) !voi
 
     const response = GetIndexResponse{
         .version = index_reader.getVersion(),
-        .segments = index_reader.getNumSegments(),
-        .docs = index_reader.getNumDocs(),
         .metadata = .{
             .metadata = blk: {
                 var managed_metadata = std.StringHashMap([]const u8).init(req.arena);

--- a/src/snapshot.zig
+++ b/src/snapshot.zig
@@ -90,7 +90,7 @@ test "index snapshot" {
             .id = 1,
             .hashes = generateRandomHashes(&hashes, 1),
         },
-    }});
+    }}, null);
 
     // Wait for checkpoint
 

--- a/tests/test_index_api.py
+++ b/tests/test_index_api.py
@@ -28,7 +28,7 @@ def test_get_index(client, index_name, create_index, fmt):
         json={
             "changes": [
                 {"insert": {"id": 1, "hashes": [101, 201, 301]}},
-                {"set_attribute": {"name": "foo", "value": 1234}},
+                {"set_metadata": {"name": "foo", "value": "1234"}},
             ],
         },
     )
@@ -41,14 +41,16 @@ def test_get_index(client, index_name, create_index, fmt):
             "version": 1,
             "segments": 1,
             "docs": 1,
-            "attributes": {"foo": 1234, "min_document_id": 1, "max_document_id": 1},
+            "metadata": {"foo": "1234"},
+            "stats": {"min_document_id": 1, "max_document_id": 1},
         }
     else:
         expected = {
             "v": 1,
             "s": 1,
             "d": 1,
-            "a": {"foo": 1234, "min_document_id": 1, "max_document_id": 1},
+            "m": {"foo": "1234"},
+            "st": {"min_document_id": 1, "max_document_id": 1},
         }
     assert decode(fmt, req.content) == expected
 

--- a/tests/test_index_api.py
+++ b/tests/test_index_api.py
@@ -28,8 +28,10 @@ def test_get_index(client, index_name, create_index, fmt):
         json={
             "changes": [
                 {"insert": {"id": 1, "hashes": [101, 201, 301]}},
-                {"set_metadata": {"name": "foo", "value": "1234"}},
             ],
+            "metadata": {
+                "foo": "1234",
+            }
         },
     )
     assert req.status_code == 200, req.content
@@ -46,7 +48,7 @@ def test_get_index(client, index_name, create_index, fmt):
         expected = {
             "v": 1,
             "m": {"foo": "1234"},
-            "st": {"min": 1, "max": 1, "s": 1, "d": 1},
+            "s": {"min_doc_id": 1, "max_doc_id": 1, "num_segments": 1, "num_docs": 1},
         }
     assert decode(fmt, req.content) == expected
 

--- a/tests/test_index_api.py
+++ b/tests/test_index_api.py
@@ -42,7 +42,7 @@ def test_get_index(client, index_name, create_index, fmt):
             "segments": 1,
             "docs": 1,
             "metadata": {"foo": "1234"},
-            "stats": {"min_document_id": 1, "max_document_id": 1},
+            "stats": {"min_doc_id": 1, "max_doc_id": 1},
         }
     else:
         expected = {
@@ -50,7 +50,7 @@ def test_get_index(client, index_name, create_index, fmt):
             "s": 1,
             "d": 1,
             "m": {"foo": "1234"},
-            "st": {"min_document_id": 1, "max_document_id": 1},
+            "st": {"min_doc_id": 1, "max_doc_id": 1},
         }
     assert decode(fmt, req.content) == expected
 

--- a/tests/test_index_api.py
+++ b/tests/test_index_api.py
@@ -39,18 +39,14 @@ def test_get_index(client, index_name, create_index, fmt):
     if fmt == "json":
         expected = {
             "version": 1,
-            "segments": 1,
-            "docs": 1,
             "metadata": {"foo": "1234"},
-            "stats": {"min_doc_id": 1, "max_doc_id": 1},
+            "stats": {"min_doc_id": 1, "max_doc_id": 1, "num_segments": 1, "num_docs": 1},
         }
     else:
         expected = {
             "v": 1,
-            "s": 1,
-            "d": 1,
             "m": {"foo": "1234"},
-            "st": {"min_doc_id": 1, "max_doc_id": 1},
+            "st": {"min": 1, "max": 1, "s": 1, "d": 1},
         }
     assert decode(fmt, req.content) == expected
 

--- a/tests/test_parallel_loading.py
+++ b/tests/test_parallel_loading.py
@@ -41,7 +41,7 @@ def test_parallel_loading_on_restart_with_multiple_segments(server, client, inde
     req = client.get(f'/{index_name}')
     assert req.status_code == 200, req.content
     index_info = json.loads(req.content)
-    initial_segments = index_info['segments']
+    initial_segments = index_info['stats']['num_segments']
     
     # Verify that multiple segments exist to ensure parallel loading will be triggered
     assert initial_segments > 1, f"Test requires multiple segments for meaningful parallel loading test, but found only {initial_segments}"
@@ -74,10 +74,10 @@ def test_parallel_loading_on_restart_with_multiple_segments(server, client, inde
     assert req.status_code == 200, req.content
     index_info_after = json.loads(req.content)
     
-    print(f"Index has {index_info_after['segments']} segments after restart")
+    print(f"Index has {index_info_after['stats']['num_segments']} segments after restart")
     
     # The number of segments might change due to background merging, but should still work
-    assert index_info_after['docs'] == total_inserts
+    assert index_info_after['stats']['num_docs'] == total_inserts
 
 
 def test_sequential_loading_with_few_segments(server, client, index_name, create_index):
@@ -97,7 +97,7 @@ def test_sequential_loading_with_few_segments(server, client, index_name, create
     assert req.status_code == 200, req.content
     index_info = json.loads(req.content)
     
-    print(f"Small index has {index_info['segments']} segments before restart")
+    print(f"Small index has {index_info['stats']['num_segments']} segments before restart")
     
     # Restart - should use sequential loading
     server.restart()


### PR DESCRIPTION
Implements the refactoring plan from issue #101:

- Renamed `attributes` to `metadata` throughout codebase
- Changed values from u64 to nullable strings for flexibility
- Separated metadata from built-in statistics in API responses
- Removed min/max document ID from attributes, moved to dedicated stats section
- Updated file format and serialization
- All unit tests pass, core functionality working

Generated with [Claude Code](https://claude.ai/code)