### PR TITLE
Remove async loading and simplify index lifecycle management

### DIFF
--- a/src/MultiIndex.zig
+++ b/src/MultiIndex.zig
@@ -231,7 +231,9 @@ pub fn deleteIndex(self: *Self, name: []const u8) !void {
         return err;
     };
 
+    // Ensure Index can safely log/use the name during deinit
+    const key_mem = entry.key_ptr.*;
     entry.value_ptr.index.deinit();
-    self.allocator.free(entry.key_ptr.*);
     self.indexes.removeByPtr(entry.key_ptr);
+    self.allocator.free(key_mem);
 }

--- a/src/MultiIndex.zig
+++ b/src/MultiIndex.zig
@@ -116,9 +116,14 @@ pub fn open(self: *Self) !void {
 
     var iter = self.dir.iterate();
     while (try iter.next()) |entry| {
-        if (entry.kind == .directory) {
-            _ = try self.openIndex(entry.name, false);
+        if (entry.kind != .directory) {
+            continue;
         }
+        if (!isValidName(entry.name)) {
+            log.warn("skipping unexpected directory {s}", .{entry.name});
+            continue;
+        }
+        _ = try self.openIndex(entry.name, false);
     }
 
     self.lock_file = lock_file;

--- a/src/MultiIndex.zig
+++ b/src/MultiIndex.zig
@@ -4,7 +4,6 @@ const assert = std.debug.assert;
 
 const Index = @import("Index.zig");
 const Scheduler = @import("utils/Scheduler.zig");
-const Future = @import("utils/Future.zig");
 
 const Self = @This();
 

--- a/src/MultiIndex.zig
+++ b/src/MultiIndex.zig
@@ -231,7 +231,7 @@ pub fn deleteIndex(self: *Self, name: []const u8) !void {
         return err;
     };
 
-    self.indexes.removeByPtr(entry.key_ptr);
-    self.allocator.free(entry.key_ptr.*);
     entry.value_ptr.index.deinit();
+    self.allocator.free(entry.key_ptr.*);
+    self.indexes.removeByPtr(entry.key_ptr);
 }

--- a/src/index_tests.zig
+++ b/src/index_tests.zig
@@ -98,7 +98,6 @@ test "index create, update, reopen and search" {
         defer index.deinit();
 
         try index.open(false);
-        try index.waitForReady(10000);
 
         var collector = SearchResults.init(std.testing.allocator, .{});
         defer collector.deinit();
@@ -157,7 +156,6 @@ test "index many updates and inserts" {
         } });
 
         if (batch.items.len == batch_size or i == total_count) {
-            try index.waitForReady(10000);
             _ = try index.update(batch.items, null, null);
 
             // Clean up allocated hashes
@@ -167,8 +165,6 @@ test "index many updates and inserts" {
             batch.clearRetainingCapacity();
         }
     }
-
-    try index.waitForReady(10000);
 
     // Verification tests
     {

--- a/src/main.zig
+++ b/src/main.zig
@@ -104,12 +104,14 @@ pub fn main() !void {
     var scheduler = Scheduler.init(allocator);
     defer scheduler.deinit();
 
+    try scheduler.start(threads);
+
     var indexes = MultiIndex.init(allocator, &scheduler, dir, .{
         .parallel_segment_loading_threshold = parallel_loading_threshold,
     });
     defer indexes.deinit();
 
-    try scheduler.start(threads);
+    try indexes.open();
 
     try server.run(allocator, &indexes, address, port, threads);
 }

--- a/src/server.zig
+++ b/src/server.zig
@@ -545,8 +545,6 @@ fn handleIndexHealth(ctx: *Context, req: *httpz.Request, res: *httpz.Response) !
     const index = try getIndex(ctx, req, res, false) orelse return;
     defer releaseIndex(ctx, index);
 
-    try index.checkReady();
-
     try res.writer().writeAll("OK\n");
 }
 

--- a/src/snapshot.zig
+++ b/src/snapshot.zig
@@ -82,7 +82,6 @@ test "index snapshot" {
     defer index.deinit();
 
     try index.open(true);
-    try index.waitForReady(1000);
 
     var hashes: [100]u32 = undefined;
     _ = try index.update(&[_]Change{.{
@@ -134,7 +133,6 @@ test "index snapshot" {
     defer index2.deinit();
 
     try index2.open(true);
-    try index2.waitForReady(1000);
 
     var index_reader2 = try index2.acquireReader();
     defer index2.releaseReader(&index_reader2);

--- a/src/utils/Scheduler.zig
+++ b/src/utils/Scheduler.zig
@@ -44,7 +44,10 @@ pub fn deinit(self: *Self) void {
     self.stop();
     self.threads.deinit(self.allocator);
 
-    std.debug.assert(self.num_tasks == 0);
+    if (self.num_tasks > 0) {
+        log.err("still have {} active tasks", .{self.num_tasks});
+        std.debug.assert(self.num_tasks == 0);
+    }
 }
 
 pub fn createTask(self: *Self, priority: Priority, comptime func: anytype, args: anytype) !Task {


### PR DESCRIPTION
- Remove async loading infrastructure from Index (open_lock, loading_finished, is_ready, load_task)
- Make index loading synchronous in open() method
- Remove waitForReady() and checkReady() methods
- Simplify MultiIndex with proper file locking and eager loading
- Update tests to remove waitForReady() calls
- Add better error handling in Scheduler deinit