### PR TITLE
Refactor server to be generic over index manager type

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -113,7 +113,7 @@ pub fn main() !void {
 
     try indexes.open();
 
-    try server.run(allocator, &indexes, address, port, threads);
+    try server.run(MultiIndex, allocator, &indexes, address, port, threads);
 }
 
 test {


### PR DESCRIPTION
- Make Context, Server, and all handler functions generic over type T
- Replace hardcoded MultiIndex dependency with generic interface
- Add HandlerWrapper generator to eliminate repetitive wrapper code
- Implement clean ServerStopper interface for signal handling
- Update run() signature: run(T, allocator, indexes, address, port, threads)

This allows the server to work with any type implementing the index interface:
- getIndex(name) / createIndex(name) / deleteIndex(name) / releaseIndex()
- Enables better testing with mock implementations
- Maintains type safety and performance (compile-time generics)

All tests pass. Server now supports: server.run(MyIndexType, ...)