### PR TITLE
Fix off-by-one error in block padding calculation

### DIFF
--- a/src/filefmt.zig
+++ b/src/filefmt.zig
@@ -206,8 +206,9 @@ pub fn writeSegmentFile(dir: std.fs.Dir, reader: anytype) !void {
 
     try buffered_writer.flush();
 
-    const padding_size = block_size - counting_writer.bytes_written % block_size;
-    try writer.writeByteNTimes(0, padding_size);
+    const rem = counting_writer.bytes_written % block_size;
+    const padding_size = if (rem == 0) 0 else block_size - rem;
+    if (padding_size > 0) try writer.writeByteNTimes(0, padding_size);
 
     var arena = std.heap.ArenaAllocator.init(std.heap.page_allocator);
     defer arena.deinit();
@@ -317,8 +318,9 @@ pub fn readSegmentFile(dir: fs.Dir, info: SegmentInfo, segment: *FileSegment) !v
     }
 
     const block_size = header.block_size;
-    const padding_size = block_size - fixed_buffer_stream.pos % block_size;
-    try fixed_buffer_stream.seekBy(@intCast(padding_size));
+    const rem = fixed_buffer_stream.pos % block_size;
+    const padding_size = if (rem == 0) 0 else block_size - rem;
+    if (padding_size > 0) try fixed_buffer_stream.seekBy(@intCast(padding_size));
 
     const blocks_data_start = fixed_buffer_stream.pos;
 


### PR DESCRIPTION
## Summary
• Fixed padding calculation in file format operations to correctly handle block-aligned data
• Previously would write/skip a full block even when no padding was needed
• Now correctly skips padding when data is already aligned to block boundaries

## Changes
• `writeSegmentFile`: Skip padding when `rem == 0` 
• `readSegmentFile`: Skip seek when `rem == 0`

## Test plan
- [x] Unit tests pass (all 55 tests)
- [x] Specific test coverage via `filefmt.test.writeFile/readFile`