### PR TITLE
Increment index generation on delete and rename version to generation

### DIFF
--- a/src/MultiIndex.zig
+++ b/src/MultiIndex.zig
@@ -185,7 +185,7 @@ fn createNewIndex(self: *Self, original_name: []const u8) !*IndexRef {
     if (!found_existing) {
         ref.redirect = IndexRedirect.init(name);
     } else {
-        ref.redirect = ref.redirect.nextVersion();
+        ref.redirect = ref.redirect.nextGeneration();
     }
     errdefer ref.redirect.deleted = true;
 
@@ -528,8 +528,8 @@ pub fn deleteIndex(self: *Self, name: []const u8) !void {
 
     log.info("deleting index {s}", .{name});
 
-    // Mark redirect as deleted
-    index_ref.redirect.deleted = true;
+    // Mark redirect as deleted with incremented generation
+    index_ref.redirect = index_ref.redirect.nextGenerationDeleted();
     errdefer index_ref.redirect.deleted = false;
 
     index_redirect.writeRedirectFile(index_ref.index_dir, index_ref.redirect, self.allocator) catch |err| {


### PR DESCRIPTION
- Renamed IndexRedirect.version field to IndexRedirect.generation
- Added nextGenerationDeleted() method to increment generation when marking index as deleted
- Updated deleteIndex() to call nextGenerationDeleted() instead of just setting deleted flag
- Updated all tests and references to use generation instead of version
- Verified all unit and integration tests pass

Now every index operation (create, update, delete) increments the generation number.