### PR TITLE
Add support for restoring indexes from HTTP tar snapshots

### DIFF
--- a/src/ClusterMultiIndex.zig
+++ b/src/ClusterMultiIndex.zig
@@ -750,6 +750,10 @@ pub fn createIndex(
         return error.InvalidIndexName;
     }
 
+    if (request.restore_from != null) {
+        return error.RestoreNotSupportedInClusterMode;
+    }
+
     // First check if index exists and get current generation
     const status = try self.getStatus(index_name);
     if (status.is_active) {

--- a/src/MultiIndex.zig
+++ b/src/MultiIndex.zig
@@ -326,12 +326,22 @@ pub fn deinit(self: *Self) void {
         self.scheduler.destroyTask(task);
     }
 
+    // Wait for any restore tasks to complete
+    var iter = self.indexes.iterator();
+    while (iter.next()) |entry| {
+        const ref = entry.value_ptr.*;
+        while (ref.being_restored) {
+            log.info("waiting for restore task to complete for index {s}", .{entry.key_ptr.*});
+            ref.restoration_complete.wait(&self.lock);
+        }
+    }
+
     if (self.lock_file) |file| {
         file.unlock();
         file.close();
     }
 
-    var iter = self.indexes.iterator();
+    iter = self.indexes.iterator();
     while (iter.next()) |entry| {
         entry.value_ptr.*.deinit();
         self.allocator.destroy(entry.value_ptr.*);

--- a/src/MultiIndex.zig
+++ b/src/MultiIndex.zig
@@ -31,6 +31,7 @@ pub const IndexOptions = struct {
     expect_generation: ?u64 = null,
     expect_does_not_exist: bool = false,
     version: ?u64 = null,
+    restore_from: ?[]const u8 = null,
 };
 
 const OptionalIndex = struct {
@@ -59,7 +60,10 @@ pub const IndexRef = struct {
     references: usize = 1,
     delete_files: bool = false,
     being_deleted: bool = false,
+    being_restored: bool = false,
+    restore_error: ?anyerror = null,
     reference_released: std.Thread.Condition = .{},
+    restoration_complete: std.Thread.Condition = .{},
 
     pub fn incRef(self: *IndexRef) void {
         self.references += 1;
@@ -173,7 +177,7 @@ fn openExistingIndex(self: *Self, path: []const u8) !*IndexRef {
     return ref;
 }
 
-fn createNewIndex(self: *Self, original_name: []const u8, generation: ?u64) !*IndexRef {
+fn createNewIndex(self: *Self, original_name: []const u8, generation: ?u64, restore_from: ?[]const u8) !*IndexRef {
     const entry = try self.indexes.getOrPut(self.allocator, original_name);
 
     const found_existing = entry.found_existing;
@@ -246,10 +250,28 @@ fn createNewIndex(self: *Self, original_name: []const u8, generation: ?u64) !*In
         ref.index.has_value = false;
     }
 
-    try ref.index.value.open(true);
+    if (restore_from) |url| {
+        // Mark as being restored
+        ref.being_restored = true;
 
-    log.debug("Index {s} created successfully", .{ref.redirect.name});
-    try index_redirect.writeRedirectFile(ref.index_dir, ref.redirect, self.allocator);
+        log.debug("Index {s} will be restored from {s}", .{ ref.redirect.name, url });
+
+        // Duplicate strings for the task
+        const index_name_copy = try self.allocator.dupe(u8, name);
+        errdefer self.allocator.free(index_name_copy);
+
+        const url_copy = try self.allocator.dupe(u8, url);
+        errdefer self.allocator.free(url_copy);
+
+        // Start restore task
+        try self.scheduler.runOnce(restoreIndexTask, .{ self, index_name_copy, url_copy });
+    } else {
+        // Normal create: open the index
+        try ref.index.value.open(true);
+
+        log.debug("Index {s} created successfully", .{ref.redirect.name});
+        try index_redirect.writeRedirectFile(ref.index_dir, ref.redirect, self.allocator);
+    }
 
     return ref;
 }
@@ -462,6 +484,75 @@ fn deleteIndexFiles(self: *Self, name: []const u8) !void {
     };
 }
 
+fn restoreIndexTask(self: *Self, index_name: []const u8, url: []const u8) void {
+    defer {
+        self.allocator.free(index_name);
+        self.allocator.free(url);
+    }
+
+    log.info("starting restore task for index {s} from {s}", .{ index_name, url });
+
+    // Get the index reference
+    self.lock.lock();
+    const index_ref = self.indexes.get(index_name);
+    if (index_ref == null) {
+        self.lock.unlock();
+        log.warn("index {s} no longer exists, aborting restore", .{index_name});
+        return;
+    }
+    if (!index_ref.?.being_restored) {
+        self.lock.unlock();
+        log.warn("index {s} is no longer being restored, aborting", .{index_name});
+        return;
+    }
+    const index = &index_ref.?.index.value;
+    self.lock.unlock();
+
+    // Download and restore the snapshot (no lock held during long operation)
+    snapshot.downloadAndRestoreSnapshot(url, index, self.allocator) catch |err| {
+        log.err("failed to restore index {s} from {s}: {}", .{ index_name, url, err });
+
+        // Clean up on failure
+        self.lock.lock();
+        defer self.lock.unlock();
+        if (self.indexes.get(index_name)) |ref| {
+            if (ref == index_ref.? and ref.being_restored) {
+                ref.restore_error = err;
+                ref.index.clear();
+                ref.being_restored = false;
+                ref.restoration_complete.broadcast();
+            }
+        }
+        return;
+    };
+
+    // Success - mark as ready
+    self.lock.lock();
+    defer self.lock.unlock();
+
+    // Verify the index ref still exists and is in the expected state
+    if (self.indexes.get(index_name)) |ref| {
+        if (ref == index_ref.? and ref.being_restored) {
+            // Write redirect file now that restore is complete
+            index_redirect.writeRedirectFile(ref.index_dir, ref.redirect, self.allocator) catch |err| {
+                log.err("failed to write redirect file after restore for index {s}: {}", .{ index_name, err });
+
+                // Treat redirect write failure same as restore failure
+                ref.restore_error = err;
+                ref.index.clear();
+                ref.being_restored = false;
+                ref.restoration_complete.broadcast();
+                return;
+            };
+
+            log.info("restore completed for index {s}", .{index_name});
+            ref.being_restored = false;
+            ref.restore_error = null;
+            ref.restoration_complete.broadcast();
+        }
+    }
+}
+
 pub fn releaseIndex(self: *Self, index: *Index) void {
     self.lock.lock();
     defer self.lock.unlock();
@@ -478,6 +569,7 @@ pub fn releaseIndex(self: *Self, index: *Index) void {
 
 fn borrowIndex(index_ref: *IndexRef) *Index {
     assert(index_ref.index.has_value);
+    assert(!index_ref.being_restored);
     index_ref.incRef();
     return &index_ref.index.value;
 }
@@ -494,9 +586,12 @@ pub fn getOrCreateIndex(self: *Self, name: []const u8, create: bool, options: In
 
     if (self.indexes.get(name)) |index_ref| {
         if (index_ref.index.has_value) {
-            // Index exists and is active
+            // Index exists and is active (or being restored)
             if (index_ref.being_deleted) {
                 return error.IndexBeingDeleted;
+            }
+            if (index_ref.being_restored) {
+                return error.IndexBeingRestored;
             }
             // Validate expected generation if provided
             if (options.expect_generation) |expect_generation| {
@@ -527,12 +622,62 @@ pub fn getOrCreateIndex(self: *Self, name: []const u8, create: bool, options: In
         return error.IndexNotFound;
     }
 
-    const index_ref = try self.createNewIndex(name, options.generation);
+    const index_ref = try self.createNewIndex(name, options.generation, options.restore_from);
+
+    // Don't borrow the index if it's being restored - caller must wait for restoration to complete
+    if (index_ref.being_restored) {
+        return error.IndexBeingRestored;
+    }
+
     return borrowIndex(index_ref);
 }
 
 pub fn getIndex(self: *Self, name: []const u8) !*Index {
     return self.getOrCreateIndex(name, false, .{});
+}
+
+pub fn waitForIndexReady(self: *Self, name: []const u8, timeout_ms: u64) !*Index {
+    self.lock.lock();
+
+    const index_ref = self.indexes.get(name) orelse {
+        self.lock.unlock();
+        return error.IndexNotFound;
+    };
+
+    if (!index_ref.being_restored) {
+        // Index is ready (or doesn't exist / deleted)
+        self.lock.unlock();
+        return self.getIndex(name);
+    }
+
+    // Wait for restoration to complete
+    var timer = try std.time.Timer.start();
+    while (index_ref.being_restored) {
+        const elapsed_ms = timer.read() / std.time.ns_per_ms;
+        if (elapsed_ms > timeout_ms) {
+            self.lock.unlock();
+            log.warn("timeout waiting for index {s} to be restored", .{name});
+            return error.RestoreTimeout;
+        }
+
+        const remaining_timeout_ns = (timeout_ms - elapsed_ms) * std.time.ns_per_ms;
+        index_ref.restoration_complete.timedWait(&self.lock, remaining_timeout_ns) catch {
+            // Timeout occurred, continue the loop to check state again
+        };
+
+        // Check if the index still exists
+        const current_ref = self.indexes.get(name) orelse {
+            self.lock.unlock();
+            return error.IndexNotFound;
+        };
+        if (current_ref != index_ref) {
+            self.lock.unlock();
+            return error.IndexNotFound;
+        }
+    }
+
+    self.lock.unlock();
+    return self.getIndex(name);
 }
 
 pub fn deleteIndex(self: *Self, name: []const u8, request: api.DeleteIndexRequest) !api.DeleteIndexResponse {
@@ -560,6 +705,9 @@ pub fn deleteIndex(self: *Self, name: []const u8, request: api.DeleteIndexReques
     // Mark as being deleted to prevent new references
     if (index_ref.being_deleted) {
         return error.IndexAlreadyBeingDeleted;
+    }
+    if (index_ref.being_restored) {
+        return error.IndexBeingRestored;
     }
     index_ref.being_deleted = true;
     defer index_ref.being_deleted = false;
@@ -699,6 +847,7 @@ pub fn getIndexInfo(
     if (!isValidName(index_name)) {
         return error.InvalidIndexName;
     }
+
     const index = try self.getIndex(index_name);
     defer self.releaseIndex(index);
 
@@ -741,7 +890,21 @@ pub fn createIndex(
     const options = IndexOptions{
         .expect_does_not_exist = request.expect_does_not_exist,
         .generation = request.generation,
+        .restore_from = request.restore_from,
     };
+
+    // Special handling for restore: create directly, don't try to get the index
+    if (request.restore_from != null) {
+        self.lock.lock();
+        defer self.lock.unlock();
+
+        const index_ref = try self.createNewIndex(index_name, request.generation, request.restore_from);
+        return api.CreateIndexResponse{
+            .version = 0,
+            .ready = false,
+            .generation = index_ref.redirect.version,
+        };
+    }
 
     const index = try self.getOrCreateIndex(index_name, true, options);
     defer self.releaseIndex(index);

--- a/src/MultiIndex.zig
+++ b/src/MultiIndex.zig
@@ -898,6 +898,17 @@ pub fn createIndex(
         self.lock.lock();
         defer self.lock.unlock();
 
+        // Check if index already exists and is live
+        if (self.indexes.get(index_name)) |existing_ref| {
+            if (existing_ref.index.has_value) {
+                // Index exists and is live - cannot restore over it
+                if (existing_ref.being_restored) {
+                    return error.IndexBeingRestored;
+                }
+                return error.IndexAlreadyExists;
+            }
+        }
+
         const index_ref = try self.createNewIndex(index_name, request.generation, request.restore_from);
         return api.CreateIndexResponse{
             .version = 0,

--- a/src/MultiIndex.zig
+++ b/src/MultiIndex.zig
@@ -253,6 +253,7 @@ fn createNewIndex(self: *Self, original_name: []const u8, generation: ?u64, rest
     if (restore_from) |url| {
         // Mark as being restored
         ref.being_restored = true;
+        errdefer ref.being_restored = false;
 
         log.debug("Index {s} will be restored from {s}", .{ ref.redirect.name, url });
 

--- a/src/MultiIndex.zig
+++ b/src/MultiIndex.zig
@@ -505,6 +505,7 @@ fn restoreIndexTask(self: *Self, index_name: []const u8, url: []const u8) void {
         log.warn("index {s} is no longer being restored, aborting", .{index_name});
         return;
     }
+    std.debug.assert(index_ref.?.index.has_value);
     const index = &index_ref.?.index.value;
     self.lock.unlock();
 

--- a/src/api.zig
+++ b/src/api.zig
@@ -34,6 +34,7 @@ pub const UpdateRequest = struct {
 pub const CreateIndexRequest = struct {
     expect_does_not_exist: bool = false,
     generation: ?u64 = null,
+    restore_from: ?[]const u8 = null,
 
     pub fn msgpackFormat() msgpack.StructFormat {
         return .{ .as_map = .{ .key = .{ .field_name_prefix = 1 } } };

--- a/src/server.zig
+++ b/src/server.zig
@@ -273,7 +273,7 @@ fn writeErrorResponse(status: u16, err: anyerror, req: *httpz.Request, res: *htt
 }
 
 fn writeIndexErrorAs404(req: *httpz.Request, res: *httpz.Response, err: anyerror, send_body: bool) !bool {
-    if (err == error.IndexBeingDeleted or err == error.IndexNotFound or err == error.InvalidIndexName) {
+    if (err == error.IndexBeingDeleted or err == error.IndexBeingRestored or err == error.IndexNotFound or err == error.InvalidIndexName) {
         if (send_body) {
             try writeErrorResponse(404, err, req, res);
         } else {
@@ -484,7 +484,15 @@ fn handlePutIndex(comptime T: type, ctx: *Context(T), req: *httpz.Request, res: 
             try writeErrorResponse(400, err, req, res);
             return;
         }
+        if (err == error.RestoreNotSupportedInClusterMode) {
+            try writeErrorResponse(400, err, req, res);
+            return;
+        }
         if (err == error.IndexBeingDeleted) {
+            try writeErrorResponse(409, err, req, res);
+            return;
+        }
+        if (err == error.IndexBeingRestored) {
             try writeErrorResponse(409, err, req, res);
             return;
         }
@@ -521,7 +529,7 @@ fn handleDeleteIndex(comptime T: type, ctx: *Context(T), req: *httpz.Request, re
             try writeErrorResponse(404, err, req, res);
             return;
         }
-        if (err == error.DeleteTimeout or err == error.IndexAlreadyBeingDeleted) {
+        if (err == error.DeleteTimeout or err == error.IndexAlreadyBeingDeleted or err == error.IndexBeingRestored) {
             try writeErrorResponse(409, err, req, res);
             return;
         }

--- a/src/snapshot.zig
+++ b/src/snapshot.zig
@@ -7,21 +7,13 @@ const index_manifest = @import("index_manifest.zig");
 const SegmentInfo = @import("segment.zig").SegmentInfo;
 const Scheduler = @import("utils/Scheduler.zig");
 
-/// Restores an index from a tar snapshot, creating a new index
+/// Restores an index from a tar snapshot into an already initialized Index
 pub fn restoreSnapshot(
     reader: anytype,
+    index: *Index,
     allocator: std.mem.Allocator,
-    scheduler: *Scheduler,
-    parent_dir: std.fs.Dir,
-    path: []const u8,
-    options: Index.Options,
-) !Index {
-    // Create index directory
-    var extract_dir = try parent_dir.makeOpenPath(path, .{ .iterate = true });
-    errdefer parent_dir.deleteTree(path) catch |err| {
-        std.log.err("failed to clean up directory {s}: {}", .{ path, err });
-    };
-    defer extract_dir.close();
+) !void {
+    _ = allocator;
 
     // Extract tar contents using iterator for pattern matching
     var file_name_buffer: [256]u8 = undefined;
@@ -38,35 +30,26 @@ pub fn restoreSnapshot(
 
         // Check if it's a manifest file
         if (filefmt.isManifestFileName(entry.name)) {
-            try extractTarEntry(entry, extract_dir);
+            try extractTarEntry(entry, index.dir);
         } else if (filefmt.isSegmentFileName(entry.name)) {
             // It's a valid segment file
-            try extractTarEntry(entry, extract_dir);
+            try extractTarEntry(entry, index.dir);
         } else {
             // Log and skip unknown files
             std.log.warn("skipping unknown file in snapshot: {s}", .{entry.name});
         }
     }
 
-    // Create and initialize the index
-    var index = try Index.init(allocator, scheduler, parent_dir, path, path, options);
-    errdefer index.deinit(); // Clean up index if open fails
-
     // Open the index to load from extracted files
     try index.open(false);
-
-    return index;
 }
 
-/// Downloads and extracts an index from a tar snapshot URL, creating a new index
-pub fn downloadAndExtractSnapshot(
+/// Downloads and restores an index from a tar snapshot URL into an already initialized Index
+pub fn downloadAndRestoreSnapshot(
     url: []const u8,
+    index: *Index,
     allocator: std.mem.Allocator,
-    scheduler: *Scheduler,
-    parent_dir: std.fs.Dir,
-    path: []const u8,
-    options: Index.Options,
-) !Index {
+) !void {
     std.log.info("downloading snapshot from {s}", .{url});
 
     // Parse the URL
@@ -121,7 +104,7 @@ pub fn downloadAndExtractSnapshot(
 
     // Stream the response directly to restoreSnapshot
     const reader = req.reader();
-    return restoreSnapshot(reader, allocator, scheduler, parent_dir, path, options);
+    return restoreSnapshot(reader, index, allocator);
 }
 
 fn extractTarEntry(entry: anytype, extract_dir: std.fs.Dir) !void {
@@ -255,11 +238,13 @@ test "index snapshot" {
 
     // Restore the snapshot using restoreSnapshot()
 
-    var tar_file_reader = std.io.fixedBufferStream(buffer.items);
-    var index2 = try restoreSnapshot(tar_file_reader.reader(), std.testing.allocator, &scheduler, tmp_dir.dir, "extract", .{
+    var index2 = try Index.init(std.testing.allocator, &scheduler, tmp_dir.dir, "extract", "extract", .{
         .min_segment_size = 1,
     });
     defer index2.deinit();
+
+    var tar_file_reader = std.io.fixedBufferStream(buffer.items);
+    try restoreSnapshot(tar_file_reader.reader(), &index2, std.testing.allocator);
 
     var index_reader2 = try index2.acquireReader();
     defer index2.releaseReader(&index_reader2);
@@ -278,11 +263,14 @@ test "restore snapshot with corrupt tar" {
     var tmp_dir = std.testing.tmpDir(.{});
     defer tmp_dir.cleanup();
 
+    var index = try Index.init(std.testing.allocator, &scheduler, tmp_dir.dir, "test_corrupt", "test_corrupt", .{});
+    defer index.deinit();
+
     // Try to restore from corrupt data
     const corrupt_data = "not a tar file";
     var reader = std.io.fixedBufferStream(corrupt_data);
 
-    const result = restoreSnapshot(reader.reader(), std.testing.allocator, &scheduler, tmp_dir.dir, "test_corrupt", .{});
+    const result = restoreSnapshot(reader.reader(), &index, std.testing.allocator);
     try std.testing.expectError(error.UnexpectedEndOfStream, result);
 }
 
@@ -296,6 +284,9 @@ test "restore snapshot cleanup on failure" {
     var tmp_dir = std.testing.tmpDir(.{});
     defer tmp_dir.cleanup();
 
+    var index = try Index.init(std.testing.allocator, &scheduler, tmp_dir.dir, "test_cleanup", "test_cleanup", .{});
+    defer index.deinit();
+
     // Create a valid tar with manifest but no segment files to trigger load failure
     var buffer = std.ArrayList(u8).init(std.testing.allocator);
     defer buffer.deinit();
@@ -308,15 +299,11 @@ test "restore snapshot cleanup on failure" {
     try tar_writer.finish();
 
     var reader = std.io.fixedBufferStream(buffer.items);
-    const result = restoreSnapshot(reader.reader(), std.testing.allocator, &scheduler, tmp_dir.dir, "test_cleanup", .{});
+    const result = restoreSnapshot(reader.reader(), &index, std.testing.allocator);
     try std.testing.expectError(error.InvalidFormat, result);
-
-    // Verify cleanup: directory should be removed entirely
-    const dir_result = tmp_dir.dir.openDir("test_cleanup", .{});
-    try std.testing.expectError(error.FileNotFound, dir_result);
 }
 
-test "downloadAndExtractSnapshot invalid URL" {
+test "downloadAndRestoreSnapshot invalid URL" {
     var scheduler = Scheduler.init(std.testing.allocator);
     defer scheduler.deinit();
 
@@ -326,19 +313,19 @@ test "downloadAndExtractSnapshot invalid URL" {
     var tmp_dir = std.testing.tmpDir(.{});
     defer tmp_dir.cleanup();
 
+    var index = try Index.init(std.testing.allocator, &scheduler, tmp_dir.dir, "test_download", "test_download", .{});
+    defer index.deinit();
+
     // Test with invalid URL
-    const result = downloadAndExtractSnapshot(
+    const result = downloadAndRestoreSnapshot(
         "not-a-valid-url",
+        &index,
         std.testing.allocator,
-        &scheduler,
-        tmp_dir.dir,
-        "test_download",
-        .{},
     );
     try std.testing.expectError(error.InvalidFormat, result);
 }
 
-test "downloadAndExtractSnapshot nonexistent host" {
+test "downloadAndRestoreSnapshot nonexistent host" {
     var scheduler = Scheduler.init(std.testing.allocator);
     defer scheduler.deinit();
 
@@ -348,14 +335,14 @@ test "downloadAndExtractSnapshot nonexistent host" {
     var tmp_dir = std.testing.tmpDir(.{});
     defer tmp_dir.cleanup();
 
+    var index = try Index.init(std.testing.allocator, &scheduler, tmp_dir.dir, "test_download", "test_download", .{});
+    defer index.deinit();
+
     // Test with nonexistent host - this should fail at the network level
-    const result = downloadAndExtractSnapshot(
+    const result = downloadAndRestoreSnapshot(
         "http://nonexistent-host-12345.invalid/file.tar",
+        &index,
         std.testing.allocator,
-        &scheduler,
-        tmp_dir.dir,
-        "test_download",
-        .{},
     );
     // This could fail with various network errors, just ensure it doesn't crash
     _ = result catch {};


### PR DESCRIPTION
## Summary

Implements async index restoration from remote tar snapshots via HTTP/HTTPS URLs.

- Added `restore_from` parameter to `CreateIndexRequest` 
- Indexes marked as `being_restored` during async download/restore
- Background task uses `Scheduler.runOnce()` for fire-and-forget execution
- Returns `ready: false` in API response when restoration in progress
- Safety checks prevent operations on indexes being restored
- Cluster mode rejects restore (incompatible with NATS synchronization)

## Implementation Details

**MultiIndex.zig:**
- New `being_restored` flag and `restoration_complete` condition variable
- `restoreIndexTask()` handles async download, restore, and error cleanup
- `waitForIndexReady()` allows blocking wait with timeout
- Safety assertion in `borrowIndex()` prevents race conditions

**snapshot.zig:**
- Refactored to work with pre-initialized Index instances
- `downloadAndRestoreSnapshot()` downloads and extracts into existing index

**HTTP API:**
- Returns `{ready: false}` for restore operations
- `IndexBeingRestored` error mapped to 404 (GET) or 409 (DELETE)
- Cluster mode returns 400 for restore attempts

## Test Coverage

All existing unit tests pass. Integration tests for the full restore flow would be beneficial but are not included in this PR.