### PR TITLE
Make fpindex executable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,4 +16,4 @@ CMD ["fpindex", "--dir", "/var/lib/acoustid-index", "--address", "0.0.0.0", "--p
 # Final stage with binary copied in
 FROM base AS final
 
-ADD zig-out/bin/fpindex /usr/bin
+ADD --chmod +x zig-out/bin/fpindex /usr/bin

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,4 +16,4 @@ CMD ["fpindex", "--dir", "/var/lib/acoustid-index", "--address", "0.0.0.0", "--p
 # Final stage with binary copied in
 FROM base AS final
 
-ADD --chmod +x zig-out/bin/fpindex /usr/bin
+ADD --chmod=755 zig-out/bin/fpindex /usr/bin


### PR DESCRIPTION
I tried using the `ghcr.io/acoustid/acoustid-index:main` image, and I had a file not found error in the logs. I checked and fpindex wasn't executable.

I checked that it was indeed the issue with this simple Dockerfile which works:
```
FROM ghcr.io/acoustid/acoustid-index:main
USER root
RUN chmod +x /usr/bin/fpindex
USER acoustid
```

So the change in this PR should fix this issue, but there might be a cleaner solution upstream fixing the zig build which should have added the permission itself.