### PR TITLE
Search results: cheap docid hash + pooled collectors

### DIFF
--- a/src/MultiIndex.zig
+++ b/src/MultiIndex.zig
@@ -22,7 +22,7 @@ const Coordinator = @import("Coordinator.zig").Coordinator;
 const LineageStatus = @import("Coordinator.zig").LineageStatus;
 const index_redirect = @import("index_redirect.zig");
 const deleteDirTree = @import("common.zig").deleteDirTree;
-const SearchResults = @import("common.zig").SearchResults;
+const SearchResultsPool = @import("common.zig").SearchResultsPool;
 const metrics = @import("metrics.zig");
 const log = std.log.scoped(.multi_index);
 
@@ -51,6 +51,9 @@ fn openOrCreateDir(parent: zio.Dir, name: []const u8) !zio.Dir {
 allocator: std.mem.Allocator,
 dir: zio.Dir,
 lock: zio.Mutex = .init,
+// Reused per-search result collectors (hit map + result list), pooled to keep
+// their capacity hot across queries. See common.SearchResultsPool.
+results_pool: SearchResultsPool,
 indexes: std.StringHashMapUnmanaged(*IndexRef) = .empty,
 checkpoint_threshold: usize = 100_000,
 // Force a checkpoint once the oldest uncheckpointed write is this old (see Index);
@@ -69,7 +72,7 @@ advertise_addr: ?[]const u8 = null,
 report_interval: zio.Duration = Replicator.default_report_interval,
 
 pub fn init(allocator: std.mem.Allocator, dir: zio.Dir) Self {
-    return .{ .allocator = allocator, .dir = dir };
+    return .{ .allocator = allocator, .dir = dir, .results_pool = SearchResultsPool.init(allocator) };
 }
 
 /// Enter replicated mode: writes append to `changelog` and a per-index consumer
@@ -122,6 +125,7 @@ pub fn deinit(self: *Self) void {
         self.allocator.free(entry.key_ptr.*);
     }
     self.indexes.deinit(self.allocator);
+    self.results_pool.deinit();
     self.dir.close();
 }
 
@@ -293,11 +297,12 @@ pub fn search(self: *Self, arena: std.mem.Allocator, name: []const u8, request: 
     defer self.releaseIndex(index);
     metrics.incSearches();
 
-    var collector = SearchResults.init(arena, .{
+    const collector = try self.results_pool.acquire(.{
         .max_results = request.limit,
         .min_score = request.min_score orelse @intCast((request.query.len + 19) / 20),
         .min_score_pct = request.score_pct,
     });
+    defer self.results_pool.release(collector);
     var reader = try index.acquireReader();
     defer reader.deinit();
 
@@ -309,7 +314,7 @@ pub fn search(self: *Self, arena: std.mem.Allocator, name: []const u8, request: 
     defer deadline.clear();
 
     var sw = zio.Stopwatch.start();
-    reader.search(request.query, &collector) catch |err| {
+    reader.search(request.query, collector) catch |err| {
         if (err == error.Canceled and deadline.check(error.Canceled)) return error.SearchTimeout;
         return err;
     };

--- a/src/common.zig
+++ b/src/common.zig
@@ -53,11 +53,29 @@ pub const SearchOptions = struct {
     min_score_pct: u32 = 10,
 };
 
+// Docid keys are dense, well-distributed integers, so AutoHashMap's default
+// (Wyhash over the key bytes) is pure overhead. std.HashMap masks the low bits of
+// the hash for the bucket and takes the top 7 bits for the fingerprint, so we need
+// entropy across the whole word: a splitmix64 finalizer gives that in a few
+// multiplies.
+pub const HitContext = struct {
+    pub fn hash(_: HitContext, key: u32) u64 {
+        var x: u64 = key;
+        x = (x ^ (x >> 30)) *% 0xbf58476d1ce4e5b9;
+        x = (x ^ (x >> 27)) *% 0x94d049bb133111eb;
+        return x ^ (x >> 31);
+    }
+    pub fn eql(_: HitContext, a: u32, b: u32) bool {
+        return a == b;
+    }
+};
+
 pub const SearchResults = struct {
     allocator: std.mem.Allocator,
     options: SearchOptions,
     results: std.ArrayListUnmanaged(SearchResult) = .empty,
-    hits: std.AutoHashMapUnmanaged(u32, Hit) = .{},
+    hits: std.HashMapUnmanaged(u32, Hit, HitContext, std.hash_map.default_max_load_percentage) = .{},
+    pool_next: ?*SearchResults = null, // intrusive free-list link, see SearchResultsPool
 
     const Hit = packed struct {
         version: u64,
@@ -74,6 +92,12 @@ pub const SearchResults = struct {
     pub fn deinit(self: *SearchResults) void {
         self.hits.deinit(self.allocator);
         self.results.deinit(self.allocator);
+    }
+
+    // Reset for reuse without giving back the map/list capacity (see SearchResultsPool).
+    pub fn clearRetainingCapacity(self: *SearchResults) void {
+        self.hits.clearRetainingCapacity();
+        self.results.clearRetainingCapacity();
     }
 
     pub fn incr(self: *SearchResults, id: u32, version: u64) !void {
@@ -133,5 +157,52 @@ pub const SearchResults = struct {
 
     pub fn getResults(self: *SearchResults) []SearchResult {
         return self.results.items;
+    }
+};
+
+// Reuses SearchResults across queries so the hit map keeps its capacity instead
+// of being reallocated and rehashed every search. Pooled entries own their memory
+// from a long-lived allocator (not a per-request arena) so it survives the
+// request. acquire() locks cancelably; release() runs from a defer, so it can't.
+pub const SearchResultsPool = struct {
+    allocator: std.mem.Allocator,
+    mutex: zio.Mutex = .init,
+    free: ?*SearchResults = null,
+
+    pub fn init(allocator: std.mem.Allocator) SearchResultsPool {
+        return .{ .allocator = allocator };
+    }
+
+    pub fn deinit(self: *SearchResultsPool) void {
+        var node = self.free;
+        while (node) |r| {
+            node = r.pool_next;
+            r.deinit();
+            self.allocator.destroy(r);
+        }
+    }
+
+    pub fn acquire(self: *SearchResultsPool, options: SearchOptions) !*SearchResults {
+        {
+            try self.mutex.lock();
+            defer self.mutex.unlock();
+            if (self.free) |r| {
+                self.free = r.pool_next;
+                r.pool_next = null;
+                r.options = options;
+                return r;
+            }
+        }
+        const r = try self.allocator.create(SearchResults);
+        r.* = SearchResults.init(self.allocator, options);
+        return r;
+    }
+
+    pub fn release(self: *SearchResultsPool, r: *SearchResults) void {
+        r.clearRetainingCapacity();
+        self.mutex.lockUncancelable();
+        defer self.mutex.unlock();
+        r.pool_next = self.free;
+        self.free = r;
     }
 };


### PR DESCRIPTION
## What

Two changes to the per-search result accumulator (`SearchResults`), driven by the search workload: a ~120-hash query produces thousands of low-score matches in the hit map, of which only the top ~10s survive `finish`.

**1. Cheap docid hash.** The hit map keyed docids through `AutoHashMap`'s default hash (Wyhash over the key bytes), which is pure overhead for dense, well-distributed integer ids. Switched to `HashMapUnmanaged(u32, Hit, HitContext, 80)` where `HitContext` is a splitmix64 finalizer — a few multiplies/shifts that mix entropy across the whole word (`std.HashMap` masks the low bits for the bucket and takes the top 7 for the fingerprint). Same swiss-table probing and SoA layout; `incr`/`finish` are unchanged since the context is zero-sized.

**2. Pooled collectors.** `SearchResultsPool` (intrusive free list) reuses `SearchResults` across queries so the hit map keeps its capacity instead of being reallocated and rehashed every search. Pooled entries own memory from `MultiIndex`'s long-lived allocator (not the per-request arena), so capacity survives the request. `acquire` locks cancelably; `release` runs from a `defer` so it locks uncancelably. The bounded top-k is copied into the arena before release, so lifetimes are unchanged.

## Not in scope

The direct-mapped accumulator array (dead at ~200M docids — footprint + all-cache-miss access) and the k-way merge that would structurally skip the false-positive flood. This is the low-risk half: cheaper per-op and no per-query reallocation, decode path untouched.

## Test

`zig build unit-tests` — 72/72 pass.