### PR TITLE
Search results: bound the collector pool, rank in place

### DIFF
--- a/src/MultiIndex.zig
+++ b/src/MultiIndex.zig
@@ -184,6 +184,10 @@ fn releaseIndex(self: *Self, index: *Index) void {
 /// semaphore (when load_concurrency > 0) caps the total file-segment loads in
 /// flight across all indexes.
 pub fn open(self: *Self) !void {
+    // 0. Start the search-collector sweeper (deinit cancels it). Before the early
+    //    return below, so an empty data dir still gets one.
+    try self.results_pool.start();
+
     // 1. Collect index names first: entry.name is only valid until the next
     //    it.next(), so we can't hold it across the concurrent opens.
     var names: std.ArrayListUnmanaged([]const u8) = .empty;

--- a/src/common.zig
+++ b/src/common.zig
@@ -94,9 +94,17 @@ pub const SearchResults = struct {
         self.results.deinit(self.allocator);
     }
 
-    // Reset for reuse without giving back the map/list capacity (see SearchResultsPool).
-    pub fn clearRetainingCapacity(self: *SearchResults) void {
-        self.hits.clearRetainingCapacity();
+    // Reset for reuse, keeping the map/list capacity so the next query doesn't have
+    // to grow them again. A query that touched an unusually large number of docs is
+    // the exception: past `max_hits_capacity` slots the map is given back rather
+    // than parked in the pool (see SearchResultsPool.max_retained_hits). `results`
+    // is bounded by api.max_search_limit, so it's always kept.
+    pub fn resetForReuse(self: *SearchResults, max_hits_capacity: u32) void {
+        if (self.hits.capacity() > max_hits_capacity) {
+            self.hits.clearAndFree(self.allocator);
+        } else {
+            self.hits.clearRetainingCapacity();
+        }
         self.results.clearRetainingCapacity();
     }
 
@@ -164,19 +172,93 @@ pub const SearchResults = struct {
 // of being reallocated and rehashed every search. Pooled entries own their memory
 // from a long-lived allocator (not a per-request arena) so it survives the
 // request. acquire() locks cancelably; release() runs from a defer, so it can't.
+//
+// The pool grows to whatever concurrency the traffic demands - a burst of 5000
+// searches parks 5000 collectors - and shrinks back afterwards via trim(), so a
+// peak doesn't cost anything once it passes. See trim() for how it decides.
 pub const SearchResultsPool = struct {
     allocator: std.mem.Allocator,
     mutex: zio.Mutex = .init,
     free: ?*SearchResults = null,
+    free_count: usize = 0,
+    // Smallest free_count seen since the last trim (see trim()).
+    low_water: usize = 0,
+    sweeper: ?zio.JoinHandle(zio.Cancelable!void) = null,
+    // How often the sweeper reclaims idle collectors. Sets the settling rate: an
+    // idle pool halves every interval (see trim()), so a burst of N collectors is
+    // gone within roughly log2(N) sweeps of the traffic dropping off.
+    trim_interval: zio.Duration = .fromMilliseconds(30_000),
+    // Cap on the hit-map capacity a parked collector may hold, in slots. One wide
+    // query against a large index can grow the map to millions of entries; without
+    // this, that peak stays resident in the pool for the life of the process.
+    max_retained_hits: u32 = 64 * 1024,
 
     pub fn init(allocator: std.mem.Allocator) SearchResultsPool {
         return .{ .allocator = allocator };
     }
 
+    /// Start the sweeper coroutine. Call once the pool is at its final address
+    /// (the coroutine captures `self`). Optional - without it the pool never
+    /// shrinks, which is fine for tests and short-lived tools.
+    pub fn start(self: *SearchResultsPool) !void {
+        self.sweeper = try zio.spawn(sweepLoop, .{self});
+    }
+
     pub fn deinit(self: *SearchResultsPool) void {
+        if (self.sweeper) |*task| {
+            task.cancel();
+            self.sweeper = null;
+        }
         var node = self.free;
         while (node) |r| {
             node = r.pool_next;
+            r.deinit();
+            self.allocator.destroy(r);
+        }
+        self.free = null;
+        self.free_count = 0;
+        self.low_water = 0;
+    }
+
+    fn sweepLoop(self: *SearchResultsPool) zio.Cancelable!void {
+        while (true) {
+            try zio.sleep(self.trim_interval);
+            self.trim();
+        }
+    }
+
+    // Free some of the collectors nobody needed during the last interval. `low_water`
+    // is the smallest the free list got, so that many entries sat untouched the whole
+    // time; give back half of them (rounded up, so it still reaches zero) and let
+    // repeated sweeps decay the rest. Halving rather than dropping the lot keeps a
+    // single quiet interval from throwing away a pool that traffic is about to want
+    // again - the cost of guessing wrong is one interval of re-allocation, but the
+    // pool still empties within a few sweeps of going idle.
+    //
+    // The list is strict LIFO - release() pushes the head, acquire() pops it - so it
+    // stays ordered by last use, and the idle ones are exactly the tail: find the cut
+    // point in one walk, detach, then free outside the lock.
+    pub fn trim(self: *SearchResultsPool) void {
+        self.mutex.lockUncancelable();
+        var idle: ?*SearchResults = null;
+        if (self.low_water > 0) {
+            const keep = self.free_count - (self.low_water + 1) / 2;
+            if (keep == 0) {
+                idle = self.free;
+                self.free = null;
+            } else {
+                var last = self.free.?;
+                for (1..keep) |_| last = last.pool_next.?;
+                idle = last.pool_next;
+                last.pool_next = null;
+            }
+            self.free_count = keep;
+        }
+        self.low_water = self.free_count;
+        self.mutex.unlock();
+
+        while (idle) |r| {
+            idle = r.pool_next;
             r.deinit();
             self.allocator.destroy(r);
         }
@@ -188,6 +270,8 @@ pub const SearchResultsPool = struct {
             defer self.mutex.unlock();
             if (self.free) |r| {
                 self.free = r.pool_next;
+                self.free_count -= 1;
+                self.low_water = @min(self.low_water, self.free_count);
                 r.pool_next = null;
                 r.options = options;
                 return r;
@@ -199,10 +283,83 @@ pub const SearchResultsPool = struct {
     }
 
     pub fn release(self: *SearchResultsPool, r: *SearchResults) void {
-        r.clearRetainingCapacity();
+        r.resetForReuse(self.max_retained_hits);
         self.mutex.lockUncancelable();
         defer self.mutex.unlock();
         r.pool_next = self.free;
         self.free = r;
+        self.free_count += 1;
     }
 };
+
+test "results pool caps the hit map a parked collector may hold" {
+    const rt = try zio.Runtime.init(std.testing.allocator, .{});
+    defer rt.deinit();
+
+    var pool = SearchResultsPool.init(std.testing.allocator);
+    pool.max_retained_hits = 16;
+    defer pool.deinit();
+
+    // A normal-sized map is kept, so the next query doesn't have to grow it again.
+    const small = try pool.acquire(.{});
+    try small.incr(1, 1);
+    pool.release(small);
+    try std.testing.expect(small.hits.capacity() > 0);
+
+    // A collector whose map ballooned gives the memory back instead of parking it.
+    const big = try pool.acquire(.{});
+    for (0..1000) |i| try big.incr(@intCast(i + 1), 1);
+    try std.testing.expect(big.hits.capacity() > pool.max_retained_hits);
+    pool.release(big);
+    try std.testing.expectEqual(0, big.hits.capacity());
+}
+
+test "results pool grows to peak concurrency and trims back to steady state" {
+    const rt = try zio.Runtime.init(std.testing.allocator, .{});
+    defer rt.deinit();
+
+    var pool = SearchResultsPool.init(std.testing.allocator);
+    defer pool.deinit();
+
+    // A burst of 8 concurrent searches: all of them get pooled, no cap in the way.
+    var burst: [8]*SearchResults = undefined;
+    for (&burst) |*r| r.* = try pool.acquire(.{});
+    for (burst) |r| pool.release(r);
+    try std.testing.expectEqual(8, pool.free_count);
+
+    // The sweep that the burst grew into reclaims nothing: the list really was empty
+    // partway through it, so there's no evidence yet that any entry is idle. It just
+    // sets the baseline.
+    pool.trim();
+    try std.testing.expectEqual(8, pool.free_count);
+
+    // Now an interval where only 2 are ever in flight. 6 collectors sat untouched;
+    // the sweep gives back half of them and leaves the decay to later sweeps.
+    useConcurrently(&pool, 2);
+    pool.trim();
+    try std.testing.expectEqual(5, pool.free_count);
+
+    // Repeated low-usage intervals decay to the working set and stop there - the
+    // 2 collectors actually in flight are never idle at sweep time.
+    for (0..4) |_| {
+        useConcurrently(&pool, 2);
+        pool.trim();
+    }
+    try std.testing.expectEqual(2, pool.free_count);
+
+    // Going fully idle drains the rest, halving each sweep.
+    pool.trim();
+    try std.testing.expectEqual(1, pool.free_count);
+    pool.trim();
+    try std.testing.expectEqual(0, pool.free_count);
+}
+
+// Simulate an interval with `n` searches in flight at once, repeated a few times so
+// the pool sees the same working set more than once.
+fn useConcurrently(pool: *SearchResultsPool, comptime n: usize) void {
+    for (0..3) |_| {
+        var live: [n]*SearchResults = undefined;
+        for (&live) |*r| r.* = pool.acquire(.{}) catch unreachable;
+        for (live) |r| pool.release(r);
+    }
+}

--- a/src/common.zig
+++ b/src/common.zig
@@ -73,6 +73,9 @@ pub const HitContext = struct {
 pub const SearchResults = struct {
     allocator: std.mem.Allocator,
     options: SearchOptions,
+    // Doubles as finish()'s scratch: it starts as every candidate and is compacted
+    // down to the top-k in place, so ranking needs no second array. Sized with the
+    // hit map rather than max_results, hence capped on reuse like the map is.
     results: std.ArrayListUnmanaged(SearchResult) = .empty,
     hits: std.HashMapUnmanaged(u32, Hit, HitContext, std.hash_map.default_max_load_percentage) = .{},
     pool_next: ?*SearchResults = null, // intrusive free-list link, see SearchResultsPool
@@ -96,16 +99,21 @@ pub const SearchResults = struct {
 
     // Reset for reuse, keeping the map/list capacity so the next query doesn't have
     // to grow them again. A query that touched an unusually large number of docs is
-    // the exception: past `max_hits_capacity` slots the map is given back rather
-    // than parked in the pool (see SearchResultsPool.max_retained_hits). `results`
-    // is bounded by api.max_search_limit, so it's always kept.
+    // the exception: past `max_hits_capacity` the memory is given back rather than
+    // parked in the pool (see SearchResultsPool.max_retained_hits). Both grow with
+    // the number of matched docs - `results` because finish() ranks in it - so both
+    // are capped.
     pub fn resetForReuse(self: *SearchResults, max_hits_capacity: u32) void {
         if (self.hits.capacity() > max_hits_capacity) {
             self.hits.clearAndFree(self.allocator);
         } else {
             self.hits.clearRetainingCapacity();
         }
-        self.results.clearRetainingCapacity();
+        if (self.results.capacity > max_hits_capacity) {
+            self.results.clearAndFree(self.allocator);
+        } else {
+            self.results.clearRetainingCapacity();
+        }
     }
 
     pub fn incr(self: *SearchResults, id: u32, version: u64) !void {
@@ -119,48 +127,45 @@ pub const SearchResults = struct {
     }
 
     pub fn finish(self: *SearchResults, collection: anytype) !void {
-        var ids = try std.ArrayListUnmanaged(u32).initCapacity(self.allocator, self.hits.count());
-        defer ids.deinit(self.allocator);
+        // Every doc over the absolute floor becomes a candidate, carrying its score
+        // so the sort is pure array work - the score used to live only in the map,
+        // which cost two probes per comparison.
+        self.results.clearRetainingCapacity();
+        try self.results.ensureTotalCapacity(self.allocator, self.hits.count());
 
         var min_score = self.options.min_score;
 
         var iter = self.hits.iterator();
         while (iter.next()) |entry| {
-            if (entry.value_ptr.*.score >= min_score) {
-                ids.appendAssumeCapacity(entry.key_ptr.*);
+            if (entry.value_ptr.score >= min_score) {
+                self.results.appendAssumeCapacity(.{ .id = entry.key_ptr.*, .score = entry.value_ptr.score });
             }
         }
 
-        std.sort.pdq(u32, ids.items, self, compareResults);
+        std.sort.pdq(SearchResult, self.results.items, {}, compareResults);
 
-        self.results.clearRetainingCapacity();
-        try self.results.ensureTotalCapacity(self.allocator, self.options.max_results);
-
-        for (ids.items) |id| {
-            if (self.results.items.len == self.options.max_results) {
-                break;
-            }
-            const hit = self.hits.get(id) orelse unreachable;
-            if (collection.hasNewerVersion(id, hit.version)) {
-                continue;
-            }
-            if (hit.score < min_score) {
-                break;
-            }
-            if (self.results.items.len == 0) {
-                min_score = @max(min_score, hit.score * self.options.min_score_pct / 100);
-            }
-            self.results.appendAssumeCapacity(.{
-                .id = id,
-                .score = hit.score,
-            });
+        // Take the top-k in place: `out` only advances when a candidate survives, so
+        // it never overtakes the read cursor and the survivors compact to the front.
+        // The map is probed only for the candidates actually examined, for their
+        // version - the rest of the sorted tail is never touched.
+        var out: usize = 0;
+        for (self.results.items) |candidate| {
+            if (out == self.options.max_results) break;
+            const hit = self.hits.get(candidate.id) orelse unreachable;
+            // A hit from a superseded version of the doc: skip it, but keep scanning.
+            if (collection.hasNewerVersion(candidate.id, hit.version)) continue;
+            // Sorted by score descending, so nothing further can clear the bar.
+            if (candidate.score < min_score) break;
+            // Relative cutoff, anchored on the best score that actually survived.
+            if (out == 0) min_score = @max(min_score, candidate.score * self.options.min_score_pct / 100);
+            self.results.items[out] = candidate;
+            out += 1;
         }
+        self.results.items.len = out;
     }
 
-    pub fn compareResults(self: *SearchResults, a: u32, b: u32) bool {
-        const a_hit = self.hits.get(a) orelse unreachable;
-        const b_hit = self.hits.get(b) orelse unreachable;
-        return a_hit.score > b_hit.score or (a_hit.score == b_hit.score and a < b);
+    fn compareResults(_: void, a: SearchResult, b: SearchResult) bool {
+        return a.score > b.score or (a.score == b.score and a.id < b.id);
     }
 
     pub fn getResults(self: *SearchResults) []SearchResult {


### PR DESCRIPTION
Follow-up to #146, which introduced the docid hash context and the pooled `SearchResults` collectors. That PR left two things open, both on the search hot path.

## Bound what the pool retains (`46cd8ab`)

As merged, the pool kept everything forever: an unbounded free list, each entry holding whatever hit-map capacity its widest query had grown into. One wide query against a large index could pin a multi-MB map for the life of the process, and nothing ever came back after a traffic peak.

Two mechanisms now bound it:

- **`max_retained_hits`** (64K slots) — a cap on the map a *parked* collector may hold. Above it, `resetForReuse` gives the memory back instead of parking it.
- **A low-watermark sweeper** — `acquire()` tracks the smallest the free list got since the last sweep, which is exactly how many collectors sat untouched for the whole interval. `trim()` gives back half of them (rounded up, so it still reaches zero), every 30s by default.

There is deliberately **no cap on the pool's size**. A burst of 5000 concurrent searches pools all 5000, because those collectors existed anyway while the burst was in flight — capping the count would just mean re-allocating during the burst. The decay is what makes the peak temporary: an idle pool halves every interval, so it drains in ~log2(N) sweeps. Halving rather than dropping the whole idle set means one quiet interval doesn't throw away a pool that traffic is about to want back; the cost of guessing wrong is one interval of re-allocation.

The free list is strict LIFO — `release()` pushes the head, `acquire()` pops it — so it stays ordered by last use and the idle entries are exactly the tail. `trim()` finds the cut point in one walk, detaches under the lock, and frees outside it.

The sweeper is a coroutine started from `MultiIndex.open()` and cancelled in `deinit()`. `start()` is optional: without it the pool simply never shrinks, which is what lets the tests drive `trim()` synchronously instead of waiting on wall-clock intervals.

## Rank in place (`f93a306`)

`finish()` built a candidate list of docids, sorted it, then copied the surviving top-k into `results`. Two costs: the list was allocated and freed on every search — it sizes with the hit map, so that's a large alloc on the hot path — and the sort comparator probed the map twice per comparison to recover the scores, n·log(n) probes to order data the map already held.

Candidates now go into `results` itself carrying their score, so the sort is pure array work, and the top-k filter compacts survivors to the front in place: the write cursor only advances on a survivor, so it never overtakes the read cursor. The map is still probed for each examined candidate's version, and nothing else.

The ranking logic is unchanged, check for check — same order of `max_results` / `hasNewerVersion` / score cutoff / relative-cutoff anchor, and the comparator is the same total order over unique ids, so pdq's instability can't reorder anything.

Tradeoff: candidate entries cost 8 bytes instead of 4 now that they carry the score. In exchange the allocation is gone entirely rather than merely pooled. `results` also grows with the match count instead of `max_results` now, so the pool's retention cap applies to it as well as to the map.

## Testing

`zig build unit-tests` — 74/74 pass, including two new cases: the retention cap (a normal map is kept, a ballooned one is handed back), and the full grow-to-peak → decay → steady-state → drain curve.