### PR TITLE
Find snapshot donors from a peer list, not a coordinator registry

### DIFF
--- a/notes/bootstrap-design.md
+++ b/notes/bootstrap-design.md
@@ -43,31 +43,46 @@ refcount keeps the segments alive for the duration of the stream (guaranteed by 
 `delete_on_destroy` retirement rule). The response is tagged with the generation so the
 restorer can verify the lineage.
 
-## Coordinator as the peer registry
+## Peer discovery: a list, not a registry
 
-The coordinator is the rendezvous point — no separate node registry, no LB, no config peer
-list. It already sees which replicas are live from their long-poll read connections; each
-replica additionally sends a **periodic status heartbeat**:
+> Superseded 2026-07-29. This section previously put a replica registry on the
+> coordinator (`POST /_status` heartbeats, a `last_seen` table, `GET /_donor`). That is
+> removed — see below for why and for what replaced it.
 
-    POST /_status
-    { replica_id, advertise_addr,
-      indexes: [ { name, generation, applied, file_version }, … ] }
+Nodes find donors among themselves. Config is a list of peer base URLs
+(`--peers http://a:8080,http://b:8080`), and **hostnames are re-resolved on every donor
+lookup** — so one URL naming a Kubernetes headless Service covers the whole cluster and
+follows it as pods come and go. Two endpoints, both on the node's existing server:
 
-The coordinator keeps `replica_id → { advertise_addr, last_seen, per-lineage {applied,
-file_version} }`, expiring entries on a `last_seen` timeout. That single table serves:
+    GET /:index/_status     -> { generation, version, file_version }
+    GET /:index/_snapshot   -> tar (already there)
 
-1. **Donor discovery** — pick a live replica whose `file_version ≥ P` for `(name, gen)`.
-2. **The below-retention trigger** — when a replica's `read(after = V)` finds
-   `V < oldest_retained`, the coordinator replies "below retention → bootstrap from
-   `<addr>` at F." Trigger + donor in one round-trip.
-3. **Retention** — truncate below `min(file_version)` across live replicas. Retention
-   safety keys on **`file_version`, not `applied`** (a donor's snapshot resumes from
-   file_version). This is why a slow-to-checkpoint replica would pin retention — the
-   age-based checkpoint prevents that.
+A bootstrapping node probes every peer concurrently and takes the highest `file_version`
+that is **strictly greater than the position it is stuck at**. That single condition does
+two jobs: it guarantees forward progress (a snapshot at or below where we already are
+would re-trigger the same below-retention read), and it excludes the node from its own
+peer list for free — so no node identity, and no `--advertise-addr`, is needed anywhere.
 
-Chosen over a per-checkpoint callback (goes stale for a quiet index, gives no liveness on
-its own) and over piggybacking on the consume path (keeps the hot, per-lineage read path
-clean). Config gains `--advertise-addr host:port`.
+Why not the registry: it made the log implementation **stateful, and therefore a
+singleton**. Two coordinator/gateway instances behind a Service each see a different
+subset of the heartbeats, so they disagree about who can donate and — worse — each
+computes retention from a partial view. Keeping it would have meant putting the registry
+in PG: a heartbeat write per replica every few seconds, on the primary, purely for
+liveness. The log half is happily stateless; don't weld it to something that isn't.
+
+What this costs: donor selection no longer rides along on the below-retention read, so
+bootstrap takes one extra round trip on a path that runs approximately never. And
+retention can no longer key on `min(file_version)` across live replicas, because the log
+no longer knows the replicas — it becomes time-based. That is safe *because* bootstrap
+works: falling off the log stops being fatal and becomes recoverable, which demotes
+retention from a correctness mechanism to a tuning knob. Keep the window well past
+`--checkpoint-age-ms` (a live peer's `file_version` is at most that stale), and alert on
+`oldest_retained` vs each node's `file_version` rather than trying to enforce it.
+
+**Kubernetes trap:** a headless Service publishes only *Ready* endpoints. Node readiness
+must therefore mean "index open and serving", **not** "caught up with the log" — else a
+cold cluster restart deadlocks: nobody is ready, DNS is empty, nobody can find a donor,
+nobody becomes ready. Filter unsuitable donors on what `_status` reports, never via DNS.
 
 ## Trigger & flow
 
@@ -95,10 +110,14 @@ rebuild. Prevented almost entirely by synchronous replication.
 2. **Donor.** In-memory tar from a pinned reader; wire `GET /:index/_snapshot`
    (generation-tagged). Reference: old `acoustid/idx/src/snapshot.zig` (drop its WAL
    inclusion and blocking I/O; port to zio).
-3. **Coordinator registry.** `POST /_status` heartbeat + live-replica table, donor
-   selection, below-retention read response. Replica gains a status-reporter coroutine.
-   Wire into the `MemoryCoordinator` stub + `coordinator_server` + `RemoteCoordinator`;
-   real retention/selection policy lands in the eventual PG gateway.
+3. **Peer discovery — DONE (2026-07-29), replaces the old "coordinator registry".**
+   `peers.zig` (URL list, DNS re-resolved per lookup, concurrent probes, donor choice)
+   + `GET /:index/_status` + `--peers`. The registry, heartbeats and `GET /_donor` are
+   gone from `Coordinator`/`coordinator_server`/`RemoteCoordinator`. Each probe is
+   bounded by a `zio.AutoCancel` (`probe_timeout`, default 5s), so a peer that accepts
+   and then wedges costs the fan-out one timeout instead of hanging it.
 4. **Restorer + orchestration.** Fetch → temp-extract → verify → atomic rename into
    `v<gen>` → open → resume at F; per-index bootstrap off the below-retention trigger in
    the consumer; plus the `position > max(id)` refuse-and-rebuild guard.
+5. **Time-based retention** in the log implementation, now that it no longer has replica
+   positions to key on. Export `oldest_retained`.

--- a/src/Coordinator.zig
+++ b/src/Coordinator.zig
@@ -111,52 +111,11 @@ pub const MetaDeleteResponse = struct {
     }
 };
 
-// ---- Replica registry (peer discovery for snapshot bootstrap) ----
-// Replicas periodically report their state; the coordinator is the rendezvous point
-// that a bootstrapping node queries for a donor. See notes/bootstrap-design.md.
-
-/// A replica's state for one lineage it holds locally.
-pub const LineageStatus = struct {
-    index_name: []const u8,
-    generation: u64,
-    applied: u64, // highest data-feed seq applied (the index version)
-    file_version: u64, // checkpointed watermark — a snapshot from this replica resumes here
-
-    pub fn msgpackFormat() msgpack.StructFormat {
-        return .{ .as_map = .{ .key = .{ .field_name_prefix = 1 } } };
-    }
-};
-
-/// A replica's periodic heartbeat: who it is, where to fetch its snapshots, and what
-/// it holds. Replaces the replica's previous status; absence past a timeout = dead.
-pub const ReplicaStatus = struct {
-    replica_id: []const u8,
-    advertise_addr: []const u8, // base URL other nodes fetch GET /:index/_snapshot from
-    lineages: []const LineageStatus,
-
-    pub fn msgpackFormat() msgpack.StructFormat {
-        return .{ .as_map = .{ .key = .{ .field_name_prefix = 1 } } };
-    }
-};
-
-/// Where a bootstrapping node should fetch a snapshot, and the watermark it will land
-/// on (so it resumes the data feed from there).
-pub const DonorInfo = struct {
-    advertise_addr: []const u8,
-    file_version: u64,
-
-    pub fn msgpackFormat() msgpack.StructFormat {
-        return .{ .as_map = .{ .key = .{ .field_name_prefix = 1 } } };
-    }
-};
-
-pub const DonorResponse = struct {
-    donor: ?DonorInfo = null,
-
-    pub fn msgpackFormat() msgpack.StructFormat {
-        return .{ .as_map = .{ .key = .{ .field_name_prefix = 1 } } };
-    }
-};
+// Peer discovery for snapshot bootstrap is deliberately NOT here. Nodes find donors
+// among themselves from a configured list of peer URLs — see peers.zig. A registry on
+// this side would make the log implementation stateful, and so a singleton: two
+// instances behind a load balancer would each hold a different subset of the
+// heartbeats and disagree about who can donate.
 
 /// Runtime-dispatched handle to a changelog implementation.
 pub const Coordinator = struct {
@@ -191,15 +150,6 @@ pub const Coordinator = struct {
         /// `out` in pos order, return the count. Ops are valid until the next call.
         readMeta: *const fn (ptr: *anyopaque, after: u64, out: []MetaOp, deadline: zio.Timeout) anyerror!usize,
 
-        // Replica registry (peer discovery).
-        /// Record/refresh a replica's heartbeat (liveness + per-lineage watermarks).
-        /// The implementation copies what it needs; `status` need not outlive the call.
-        reportStatus: *const fn (ptr: *anyopaque, status: ReplicaStatus) anyerror!void,
-        /// Pick a live replica able to donate a snapshot of (`index_name`,
-        /// `generation`) that a reader at `after` can resume from (file_version >=
-        /// `after`), or null if none. The returned addr is allocated in `arena`.
-        findDonor: *const fn (ptr: *anyopaque, arena: std.mem.Allocator, index_name: []const u8, generation: u64, after: u64) anyerror!?DonorInfo,
-
         /// Retention control: seqs <= `floor` are considered dropped for the lineage, so
         /// a `read(after < floor)` returns error.BelowRetention. The PG impl derives this
         /// from real retention; the stub takes it explicitly (admin/tests).
@@ -226,14 +176,6 @@ pub const Coordinator = struct {
         return self.vtable.readMeta(self.ptr, after, out, deadline);
     }
 
-    pub fn reportStatus(self: Coordinator, status: ReplicaStatus) !void {
-        return self.vtable.reportStatus(self.ptr, status);
-    }
-
-    pub fn findDonor(self: Coordinator, arena: std.mem.Allocator, index_name: []const u8, generation: u64, after: u64) !?DonorInfo {
-        return self.vtable.findDonor(self.ptr, arena, index_name, generation, after);
-    }
-
     pub fn setRetentionFloor(self: Coordinator, index_name: []const u8, generation: u64, floor: u64) !void {
         return self.vtable.setRetentionFloor(self.ptr, index_name, generation, floor);
     }
@@ -249,28 +191,11 @@ pub const MemoryCoordinator = struct {
     // Meta feed (index registry), global, never truncated.
     meta_ops: std.ArrayListUnmanaged(MetaEntry) = .empty,
     next_meta_pos: u64 = 1,
-    // Replica registry (peer discovery), keyed by replica_id.
-    replicas: std.ArrayListUnmanaged(ReplicaRecord) = .empty,
     // Simulated changelog retention per lineage: seqs <= floor are conceptually
     // dropped. The stub never truncates on its own (setRetentionFloor drives it in
     // tests); the PG impl computes this from real retention.
     retention: std.ArrayListUnmanaged(RetentionFloor) = .empty,
 
-    // A replica whose heartbeat is older than this is treated as dead.
-    const liveness_timeout: zio.Duration = .fromMilliseconds(30_000);
-
-    const ReplicaRecord = struct {
-        replica_id: []const u8, // owned
-        advertise_addr: []const u8, // owned
-        lineages: []OwnedLineage, // owned
-        last_seen: zio.Timestamp,
-    };
-    const OwnedLineage = struct {
-        index_name: []const u8, // owned
-        generation: u64,
-        applied: u64,
-        file_version: u64,
-    };
     const RetentionFloor = struct {
         index_name: []const u8, // owned
         generation: u64,
@@ -299,8 +224,6 @@ pub const MemoryCoordinator = struct {
         self.rows.deinit(self.allocator);
         for (self.meta_ops.items) |op| self.allocator.free(op.index_name);
         self.meta_ops.deinit(self.allocator);
-        for (self.replicas.items) |*rec| self.freeReplicaRecord(rec);
-        self.replicas.deinit(self.allocator);
         for (self.retention.items) |r| self.allocator.free(r.index_name);
         self.retention.deinit(self.allocator);
         self.* = undefined;
@@ -316,8 +239,6 @@ pub const MemoryCoordinator = struct {
         .createIndex = createIndexImpl,
         .deleteIndex = deleteIndexImpl,
         .readMeta = readMetaImpl,
-        .reportStatus = reportStatusImpl,
-        .findDonor = findDonorImpl,
         .setRetentionFloor = setRetentionFloorImpl,
     };
 
@@ -400,80 +321,6 @@ pub const MemoryCoordinator = struct {
     fn freeRow(self: *MemoryCoordinator, row: *Row) void {
         self.allocator.free(row.index_name);
         freeChange(self.allocator, row.change);
-    }
-
-    fn reportStatusImpl(ptr: *anyopaque, status: ReplicaStatus) anyerror!void {
-        const self: *MemoryCoordinator = @ptrCast(@alignCast(ptr));
-        try self.mutex.lock();
-        defer self.mutex.unlock();
-
-        // Build the owned replacement first, so a mid-build failure leaves the old
-        // record intact.
-        var rec = try self.dupeReplicaRecord(status);
-        errdefer self.freeReplicaRecord(&rec);
-
-        for (self.replicas.items) |*existing| {
-            if (std.mem.eql(u8, existing.replica_id, status.replica_id)) {
-                self.freeReplicaRecord(existing);
-                existing.* = rec;
-                return;
-            }
-        }
-        try self.replicas.append(self.allocator, rec);
-    }
-
-    fn findDonorImpl(ptr: *anyopaque, arena: std.mem.Allocator, index_name: []const u8, generation: u64, after: u64) anyerror!?DonorInfo {
-        const self: *MemoryCoordinator = @ptrCast(@alignCast(ptr));
-        try self.mutex.lock();
-        defer self.mutex.unlock();
-
-        var best_addr: ?[]const u8 = null;
-        var best_fv: u64 = 0;
-        for (self.replicas.items) |rec| {
-            if (rec.last_seen.untilNow(.monotonic).toNanoseconds() > liveness_timeout.toNanoseconds()) continue; // dead
-            for (rec.lineages) |ls| {
-                if (ls.generation != generation) continue;
-                if (!std.mem.eql(u8, ls.index_name, index_name)) continue;
-                if (ls.file_version < after) continue; // a reader at `after` can't resume from here
-                if (best_addr == null or ls.file_version > best_fv) {
-                    best_addr = rec.advertise_addr;
-                    best_fv = ls.file_version;
-                }
-            }
-        }
-        const addr = best_addr orelse return null;
-        // Copy the addr into the caller's arena — the record may change after unlock.
-        return .{ .advertise_addr = try arena.dupe(u8, addr), .file_version = best_fv };
-    }
-
-    fn dupeReplicaRecord(self: *MemoryCoordinator, status: ReplicaStatus) !ReplicaRecord {
-        const id = try self.allocator.dupe(u8, status.replica_id);
-        errdefer self.allocator.free(id);
-        const addr = try self.allocator.dupe(u8, status.advertise_addr);
-        errdefer self.allocator.free(addr);
-        const lineages = try self.allocator.alloc(OwnedLineage, status.lineages.len);
-        var n: usize = 0;
-        errdefer {
-            for (lineages[0..n]) |l| self.allocator.free(l.index_name);
-            self.allocator.free(lineages);
-        }
-        for (status.lineages) |ls| {
-            lineages[n] = .{
-                .index_name = try self.allocator.dupe(u8, ls.index_name),
-                .generation = ls.generation,
-                .applied = ls.applied,
-                .file_version = ls.file_version,
-            };
-            n += 1;
-        }
-        return .{ .replica_id = id, .advertise_addr = addr, .lineages = lineages, .last_seen = zio.Timestamp.now(.monotonic) };
-    }
-
-    fn freeReplicaRecord(self: *MemoryCoordinator, rec: *ReplicaRecord) void {
-        self.allocator.free(rec.replica_id);
-        self.allocator.free(rec.advertise_addr);
-        for (rec.lineages) |l| self.allocator.free(l.index_name);
-        self.allocator.free(rec.lineages);
     }
 
     fn retentionFloorLocked(self: *MemoryCoordinator, index_name: []const u8, generation: u64) u64 {
@@ -757,51 +604,6 @@ test "MemoryCoordinator: meta feed create/delete/create, distinct generations, i
 
     // Deleting a name that isn't active is a no-op: returns the latest meta pos.
     try testing.expectEqual(other, try co.deleteIndex("does_not_exist"));
-}
-
-test "MemoryCoordinator: findDonor picks a live replica that can serve the reader" {
-    const rt = try zio.Runtime.init(testing.allocator, .{});
-    defer rt.deinit();
-
-    var cl = MemoryCoordinator.init(testing.allocator);
-    defer cl.deinit();
-    const co = cl.coordinator();
-
-    var arena = std.heap.ArenaAllocator.init(testing.allocator);
-    defer arena.deinit();
-    const a = arena.allocator();
-
-    // No replicas yet -> no donor.
-    try testing.expect((try co.findDonor(a, "main", 1, 0)) == null);
-
-    try co.reportStatus(.{ .replica_id = "r1", .advertise_addr = "http://r1", .lineages = &.{
-        .{ .index_name = "main", .generation = 1, .applied = 10, .file_version = 5 },
-    } });
-    try co.reportStatus(.{ .replica_id = "r2", .advertise_addr = "http://r2", .lineages = &.{
-        .{ .index_name = "main", .generation = 1, .applied = 20, .file_version = 15 },
-        .{ .index_name = "other", .generation = 3, .applied = 4, .file_version = 4 },
-    } });
-
-    // A reader at after=0: both qualify, prefer the higher checkpoint watermark (r2).
-    const d = (try co.findDonor(a, "main", 1, 0)).?;
-    try testing.expectEqualStrings("http://r2", d.advertise_addr);
-    try testing.expectEqual(@as(u64, 15), d.file_version);
-
-    // A reader past r1's watermark (after=10): only r2 (fv 15) can resume it.
-    try testing.expectEqualStrings("http://r2", (try co.findDonor(a, "main", 1, 10)).?.advertise_addr);
-    // Past everyone (after=20): no donor.
-    try testing.expect((try co.findDonor(a, "main", 1, 20)) == null);
-    // Wrong generation / name -> no donor.
-    try testing.expect((try co.findDonor(a, "main", 2, 0)) == null);
-    try testing.expect((try co.findDonor(a, "nope", 1, 0)) == null);
-
-    // A replica re-reporting replaces its prior status (no leak; new watermark wins).
-    try co.reportStatus(.{ .replica_id = "r1", .advertise_addr = "http://r1b", .lineages = &.{
-        .{ .index_name = "main", .generation = 1, .applied = 40, .file_version = 30 },
-    } });
-    const d3 = (try co.findDonor(a, "main", 1, 20)).?;
-    try testing.expectEqualStrings("http://r1b", d3.advertise_addr);
-    try testing.expectEqual(@as(u64, 30), d3.file_version);
 }
 
 test "MemoryCoordinator: read below the retention floor signals bootstrap" {

--- a/src/MultiIndex.zig
+++ b/src/MultiIndex.zig
@@ -19,7 +19,6 @@ const Metadata = @import("change.zig").Metadata;
 const MetadataEntry = @import("change.zig").MetadataEntry;
 const Replicator = @import("Replicator.zig");
 const Coordinator = @import("Coordinator.zig").Coordinator;
-const LineageStatus = @import("Coordinator.zig").LineageStatus;
 const index_redirect = @import("index_redirect.zig");
 const deleteDirTree = @import("common.zig").deleteDirTree;
 const SearchResultsPool = @import("common.zig").SearchResultsPool;
@@ -65,11 +64,6 @@ sync: bool = true,
 load_concurrency: usize = 0,
 // Set in replicated mode: writes go through the log, a consumer applies them.
 replication: ?*Replicator = null,
-// Base URL other nodes fetch GET /:index/_snapshot from; enables the status reporter
-// (peer discovery) when set. Only meaningful in replicated mode.
-advertise_addr: ?[]const u8 = null,
-// How often the status reporter heartbeats the coordinator.
-report_interval: zio.Duration = Replicator.default_report_interval,
 
 pub fn init(allocator: std.mem.Allocator, dir: zio.Dir) Self {
     return .{ .allocator = allocator, .dir = dir, .results_pool = SearchResultsPool.init(allocator) };
@@ -81,34 +75,27 @@ pub fn startReplication(self: *Self, coordinator: Coordinator) !void {
     const repl = try self.allocator.create(Replicator);
     errdefer self.allocator.destroy(repl);
     repl.* = Replicator.init(self.allocator, self, coordinator);
-    repl.advertise_addr = self.advertise_addr;
-    repl.report_interval = self.report_interval;
     errdefer repl.deinit();
     try repl.start();
     self.replication = repl;
 }
 
-// Snapshot each active index's lineage watermarks for the status reporter. Reads a
-// pinned reader per index (consistent applied/file_version) under the lock; names are
-// copied into `arena`.
-pub fn collectLineageStatus(self: *Self, arena: std.mem.Allocator) ![]LineageStatus {
-    try self.lock.lock();
-    defer self.lock.unlock();
-    var list: std.ArrayListUnmanaged(LineageStatus) = .empty;
-    var it = self.indexes.iterator();
-    while (it.next()) |e| {
-        const ref = e.value_ptr.*;
-        if (ref.being_deleted) continue;
-        var r = try ref.index.acquireReader();
-        defer r.deinit();
-        try list.append(arena, .{
-            .index_name = try arena.dupe(u8, e.key_ptr.*),
-            .generation = ref.generation,
-            .applied = r.snapshot.value.version,
-            .file_version = r.snapshot.value.file_version,
-        });
-    }
-    return list.toOwnedSlice(arena);
+/// This node's lineage watermarks for one index, as served to peers looking for a
+/// snapshot donor (GET /:index/_status). A single pinned reader gives a consistent
+/// version/file_version pair.
+pub fn getPeerStatus(self: *Self, name: []const u8) !api.PeerStatusResponse {
+    const index = try self.getIndex(name);
+    defer self.releaseIndex(index);
+    const ref: *IndexRef = @fieldParentPtr("index", index);
+
+    var reader = try index.acquireReader();
+    defer reader.deinit();
+
+    return .{
+        .generation = ref.generation,
+        .version = reader.snapshot.value.version,
+        .file_version = reader.snapshot.value.file_version,
+    };
 }
 
 pub fn deinit(self: *Self) void {

--- a/src/RemoteCoordinator.zig
+++ b/src/RemoteCoordinator.zig
@@ -24,9 +24,6 @@ const ReadResponse = changelog_mod.ReadResponse;
 const MetaReadResponse = changelog_mod.MetaReadResponse;
 const MetaCreateResponse = changelog_mod.MetaCreateResponse;
 const MetaDeleteResponse = changelog_mod.MetaDeleteResponse;
-const ReplicaStatus = changelog_mod.ReplicaStatus;
-const DonorInfo = changelog_mod.DonorInfo;
-const DonorResponse = changelog_mod.DonorResponse;
 
 const Self = @This();
 // Cap on any single long-poll window (server side may still return sooner). Used
@@ -65,8 +62,6 @@ const vtable: Coordinator.VTable = .{
     .createIndex = createIndexImpl,
     .deleteIndex = deleteIndexImpl,
     .readMeta = readMetaImpl,
-    .reportStatus = reportStatusImpl,
-    .findDonor = findDonorImpl,
     .setRetentionFloor = setRetentionFloorImpl,
 };
 
@@ -170,43 +165,6 @@ fn readMetaImpl(ptr: *anyopaque, after: u64, out: []MetaOp, deadline: zio.Timeou
     const n = @min(mres.ops.len, out.len);
     for (mres.ops[0..n], 0..) |op, i| out[i] = op;
     return n;
-}
-
-fn reportStatusImpl(ptr: *anyopaque, status: ReplicaStatus) anyerror!void {
-    const self: *Self = @ptrCast(@alignCast(ptr));
-    var arena = std.heap.ArenaAllocator.init(self.allocator);
-    defer arena.deinit();
-    const a = arena.allocator();
-
-    var aw: std.Io.Writer.Allocating = .init(a);
-    try msgpack.encode(status, &aw.writer);
-    const url = try std.fmt.allocPrint(a, "{s}/_status", .{self.base_url});
-
-    var client = http.Client.init(self.allocator, self.io, .{});
-    defer client.deinit();
-    var resp = try client.fetch(url, .{ .method = .post, .body = aw.written() });
-    defer resp.deinit();
-    if (resp.status() != .ok) return statusToError(resp.status());
-}
-
-fn findDonorImpl(ptr: *anyopaque, arena: std.mem.Allocator, index_name: []const u8, generation: u64, after: u64) anyerror!?DonorInfo {
-    const self: *Self = @ptrCast(@alignCast(ptr));
-    var tmp = std.heap.ArenaAllocator.init(self.allocator);
-    defer tmp.deinit();
-    const a = tmp.allocator();
-
-    const url = try std.fmt.allocPrint(a, "{s}/_donor/{s}/{d}?after={d}", .{ self.base_url, index_name, generation, after });
-    var client = http.Client.init(self.allocator, self.io, .{});
-    defer client.deinit();
-    var resp = try client.fetch(url, .{ .method = .get });
-    defer resp.deinit();
-    if (resp.status() != .ok) return statusToError(resp.status());
-
-    const body = (try resp.body()) orelse return null;
-    const dres = try msgpack.decodeFromSliceLeaky(DonorResponse, a, body);
-    const d = dres.donor orelse return null;
-    // Copy the addr into the caller's arena; `tmp` (and the decoded body) is freed here.
-    return .{ .advertise_addr = try arena.dupe(u8, d.advertise_addr), .file_version = d.file_version };
 }
 
 fn setRetentionFloorImpl(ptr: *anyopaque, index_name: []const u8, generation: u64, floor: u64) anyerror!void {

--- a/src/Replicator.zig
+++ b/src/Replicator.zig
@@ -31,6 +31,7 @@ const Coordinator = coordinator_mod.Coordinator;
 const Entry = coordinator_mod.Entry;
 const MetaOp = coordinator_mod.MetaOp;
 const Change = @import("change.zig").Change;
+const peers_mod = @import("peers.zig");
 const api = @import("api.zig");
 const log = std.log.scoped(.replicator);
 
@@ -54,8 +55,10 @@ const pending_retry: zio.Timeout = .{ .duration = .fromMilliseconds(1000) };
 // error.ReplicationTimeout (-> 503) instead of hanging the request forever.
 // Overridable per-instance (`ryw_timeout` field); tests set it short.
 pub const default_ryw_timeout: zio.Duration = .fromMilliseconds(30_000);
-// How often the status reporter heartbeats the coordinator (overridable per-instance).
-pub const default_report_interval: zio.Duration = .fromMilliseconds(5_000);
+// Deadline for the "can I resume from this watermark?" read that vets a donor before
+// we transfer its snapshot. Only ever waits when the answer is yes and the feed is
+// idle — BelowRetention comes back immediately — so this just bounds that idle case.
+const resume_probe: zio.Timeout = .{ .duration = .fromMilliseconds(500) };
 
 allocator: std.mem.Allocator,
 mi: *MultiIndex,
@@ -67,15 +70,12 @@ consumers: std.StringHashMapUnmanaged(*Consumer) = .empty,
 meta_applied: u64 = 0, // max meta pos reconciled (guarded by mutex)
 meta_task: ?zio.JoinHandle(zio.Cancelable!void) = null,
 ryw_timeout: zio.Duration = default_ryw_timeout, // read/create/delete-your-writes budget
-// Peer-discovery heartbeat. When advertise_addr is set (the base URL other nodes fetch
-// GET /:index/_snapshot from), a reporter coroutine periodically tells the coordinator
-// what this node holds, so it can be picked as a snapshot donor. null disables it.
-advertise_addr: ?[]const u8 = null,
-report_interval: zio.Duration = default_report_interval,
-report_task: ?zio.JoinHandle(zio.Cancelable!void) = null,
-// HTTP client for fetching snapshots from donor peers on bootstrap. Set by main (from
-// the runtime's io) once replication starts; null in tests that never bootstrap.
-http_client: ?http.Client = null,
+// Where snapshot donors are looked up when a consumer falls below retention. Set by
+// main once replication starts; null (the default, for tests that never bootstrap)
+// makes a bootstrap attempt fail with error.NoPeersConfigured.
+peers: ?peers_mod = null,
+// Runtime io, for the snapshot fetch's HTTP client. Set by main alongside `peers`.
+io: ?std.Io = null,
 
 const Consumer = struct {
     name: []const u8, // owned; also the map key
@@ -96,11 +96,7 @@ pub fn init(allocator: std.mem.Allocator, mi: *MultiIndex, coordinator: Coordina
 }
 
 pub fn deinit(self: *Self) void {
-    // Stop the reporter first (it walks MultiIndex's indexes).
-    if (self.report_task) |*t| t.cancel(); // cancel + join
-    self.report_task = null;
-
-    // Stop the meta consumer next so it can't create/delete more indexes while we
+    // Stop the meta consumer first so it can't create/delete more indexes while we
     // tear the data consumers down.
     if (self.meta_task) |*t| t.cancel(); // cancel + join
     self.meta_task = null;
@@ -113,8 +109,6 @@ pub fn deinit(self: *Self) void {
         self.allocator.destroy(c);
     }
     self.consumers.deinit(self.allocator);
-
-    if (self.http_client) |*c| c.deinit();
 }
 
 /// Start the meta consumer (called once after open(), before serving). It
@@ -122,29 +116,6 @@ pub fn deinit(self: *Self) void {
 /// consumers are started by the reconcile path, not here.
 pub fn start(self: *Self) !void {
     self.meta_task = try zio.spawn(metaLoop, .{self});
-    if (self.advertise_addr != null) self.report_task = try zio.spawn(reportLoop, .{self});
-}
-
-// Periodically tell the coordinator what lineages this node holds and their watermarks,
-// so it can be discovered as a snapshot donor. Report failures are transient (the
-// coordinator may be briefly unreachable) — log and retry next tick.
-fn reportLoop(self: *Self) zio.Cancelable!void {
-    var arena = std.heap.ArenaAllocator.init(self.allocator);
-    defer arena.deinit();
-    while (true) {
-        _ = arena.reset(.retain_capacity);
-        self.reportOnce(arena.allocator()) catch |err| {
-            if (err == error.Canceled) return error.Canceled;
-            log.warn("status report failed: {}", .{err});
-        };
-        try zio.sleep(self.report_interval);
-    }
-}
-
-fn reportOnce(self: *Self, arena: std.mem.Allocator) !void {
-    const addr = self.advertise_addr.?;
-    const lineages = try self.mi.collectLineageStatus(arena);
-    try self.coordinator.reportStatus(.{ .replica_id = addr, .advertise_addr = addr, .lineages = lineages });
 }
 
 /// Start a data consumer for the (`name`, `generation`) lineage beginning at
@@ -239,23 +210,79 @@ fn markApplied(self: *Self, c: *Consumer, version: u64) void {
     self.cond.broadcast();
 }
 
-// Fetch a snapshot of (c.name, c.generation) from a donor the coordinator points us at
-// and swap it into the local index, returning the version to resume from. The donor is
-// picked for freshness, so its watermark clears the retention floor that triggered this.
+// Fetch a snapshot of (c.name, c.generation) from a peer and swap it into the local
+// index, returning the version to resume from. Donors come back freshest first.
+//
+// Each candidate's watermark is checked against the SOURCE before we fetch from it:
+// a snapshot only helps if the log can still serve the tail above it, and the log is
+// the only thing that knows its own retention floor. Downloading first and finding out
+// afterwards costs a full index transfer per attempt — the expensive way to learn
+// something one cheap read answers. See canResumeFrom.
+//
+// Walking the list matters for the other failure: the freshest peer can fail to SERVE
+// (mid-bootstrap itself, failing disk, connection reset mid-tar), and retrying would
+// rank that same peer first every time — one sick peer would otherwise wedge bootstrap
+// for good.
 fn bootstrapConsumer(self: *Self, c: *Consumer, after: u64) !u64 {
     var arena = std.heap.ArenaAllocator.init(self.allocator);
     defer arena.deinit();
     const a = arena.allocator();
 
-    const donor = (try self.coordinator.findDonor(a, c.name, c.generation, after)) orelse return error.NoDonor;
-    const client = if (self.http_client) |*cl| cl else return error.NoHttpClient;
+    const p = self.peers orelse return error.NoPeersConfigured;
+    const donors = try p.findDonors(a, c.name, c.generation, after);
+    if (donors.len == 0) return error.NoDonor;
 
-    const url = try std.fmt.allocPrint(a, "{s}/{s}/_snapshot", .{ donor.advertise_addr, c.name });
+    var last_err: anyerror = error.NoDonor;
+    for (donors) |donor| {
+        if (!try self.canResumeFrom(c, donor.file_version)) {
+            // Donors are sorted by file_version descending and the floor is the same
+            // for all of them, so if this one is too old every one after it is too.
+            // Stop rather than re-asking the coordinator once per peer.
+            log.err(
+                "no peer can seed '{s}' gen {d}: freshest watermark {d} is below the log's retention floor — the cluster cannot self-heal, it needs a rebuild from source",
+                .{ c.name, c.generation, donor.file_version },
+            );
+            return error.AllDonorsBelowRetention;
+        }
+        return self.fetchFrom(a, c, donor) catch |err| {
+            if (err == error.Canceled) return error.Canceled;
+            log.warn("donor {s} failed for '{s}' gen {d}: {}", .{ donor.base_url, c.name, c.generation, err });
+            last_err = err;
+            continue;
+        };
+    }
+    return last_err;
+}
+
+// Would the log still serve us the tail above `file_version`? A read at that position
+// answers definitively and immediately: the retention floor is checked before the feed
+// blocks, so this never waits for new entries. 0 entries (deadline) means "resumable,
+// nothing new yet", which is a perfectly good answer.
+//
+// Errors other than BelowRetention propagate: if the log is unreachable there is no
+// point pulling a snapshot we could not resume from anyway.
+fn canResumeFrom(self: *Self, c: *Consumer, file_version: u64) !bool {
+    var probe: [1]Entry = undefined;
+    _ = self.coordinator.read(c.name, c.generation, file_version, &probe, resume_probe) catch |err| {
+        if (err == error.BelowRetention) return false;
+        return err;
+    };
+    return true;
+}
+
+fn fetchFrom(self: *Self, arena: std.mem.Allocator, c: *Consumer, donor: peers_mod.Donor) !u64 {
+    const url = try std.fmt.allocPrint(arena, "{s}/{s}/_snapshot", .{ donor.base_url, c.name });
+
+    // A client per fetch: dusty's connection pool has no locking, and two indexes can
+    // bootstrap concurrently. Same reason peers.zig builds one per probe.
+    var client = http.Client.init(self.allocator, self.io orelse return error.NoIo, .{});
+    defer client.deinit();
+
     var resp = try client.fetch(url, .{ .method = .get });
     defer resp.deinit();
     if (resp.status() != .ok) return error.SnapshotFetchFailed;
 
-    log.info("bootstrapping '{s}' gen {d} from {s} (watermark {d})", .{ c.name, c.generation, donor.advertise_addr, donor.file_version });
+    log.info("bootstrapping '{s}' gen {d} from {s} (watermark {d})", .{ c.name, c.generation, donor.base_url, donor.file_version });
     return self.mi.bootstrapLineage(c.name, c.generation, resp.reader());
 }
 
@@ -577,7 +604,7 @@ test "replicated create+update flows through the coordinator; RYW + search see i
     try std.testing.expectEqual(@as(u32, 42), s2.results[0].id);
 }
 
-test "status reporter publishes local lineages so the coordinator can find a donor" {
+test "a donor watermark below the log's retention floor is rejected before any transfer" {
     const MemoryCoordinator = coordinator_mod.MemoryCoordinator;
     const common = @import("common.zig");
 
@@ -585,7 +612,7 @@ test "status reporter publishes local lineages so the coordinator can find a don
     defer rt.deinit();
 
     const cwd = zio.Dir.cwd();
-    const dir_path = "test_replicator_reporter";
+    const dir_path = "test_replicator_resume_check";
     common.deleteDirTree(std.testing.allocator, cwd, dir_path) catch {};
     try cwd.createDir(dir_path, 0o755);
     defer common.deleteDirTree(std.testing.allocator, cwd, dir_path) catch {};
@@ -596,10 +623,52 @@ test "status reporter publishes local lineages so the coordinator can find a don
 
     var mi = MultiIndex.init(std.testing.allocator, dir);
     defer mi.deinit();
-    // Start without the reporter coroutine, then enable reportOnce manually so this
-    // test is deterministic (no background report racing the one below).
     try mi.startReplication(cl.coordinator());
-    mi.replication.?.advertise_addr = "http://self:8080";
+
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+    const a = arena.allocator();
+
+    const created = try mi.createIndex("main", .{});
+    var h = [_]u32{ 10, 20, 30 };
+    for (0..4) |i| {
+        _ = try mi.update(a, "main", .{ .changes = &[_]Change{.{ .insert = .{ .id = @intCast(i + 1), .hashes = &h } }} });
+    }
+
+    // The log has dropped everything at or below seq 2.
+    try cl.coordinator().setRetentionFloor("main", created.generation, 2);
+
+    const repl = mi.replication.?;
+    const c = repl.consumers.get("main").?;
+
+    // A donor snapshot taken at 1 is useless: we would transfer the whole index and
+    // then immediately fail the same below-retention read that sent us here.
+    try std.testing.expect(!try repl.canResumeFrom(c, 1));
+    // At the floor and above, the log can still serve the tail.
+    try std.testing.expect(try repl.canResumeFrom(c, 2));
+    try std.testing.expect(try repl.canResumeFrom(c, 4));
+}
+
+test "peer status reports the lineage watermarks a donor is picked on" {
+    const MemoryCoordinator = coordinator_mod.MemoryCoordinator;
+    const common = @import("common.zig");
+
+    const rt = try zio.Runtime.init(std.testing.allocator, .{ .executors = .exact(2) });
+    defer rt.deinit();
+
+    const cwd = zio.Dir.cwd();
+    const dir_path = "test_replicator_peer_status";
+    common.deleteDirTree(std.testing.allocator, cwd, dir_path) catch {};
+    try cwd.createDir(dir_path, 0o755);
+    defer common.deleteDirTree(std.testing.allocator, cwd, dir_path) catch {};
+    const dir = try cwd.openDir(dir_path, .{ .iterate = true });
+
+    var cl = MemoryCoordinator.init(std.testing.allocator);
+    defer cl.deinit();
+
+    var mi = MultiIndex.init(std.testing.allocator, dir);
+    defer mi.deinit();
+    try mi.startReplication(cl.coordinator());
 
     var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
     defer arena.deinit();
@@ -609,19 +678,16 @@ test "status reporter publishes local lineages so the coordinator can find a don
     var h = [_]u32{ 10, 20, 30 };
     _ = try mi.update(a, "main", .{ .changes = &[_]Change{.{ .insert = .{ .id = 1, .hashes = &h } }} });
 
-    // No checkpoint yet (file_version 0), but a reader at after=0 can still be served
-    // (an empty snapshot resumed from 0). Report once, then the coordinator can pick us.
-    try mi.replication.?.reportOnce(a);
-    const donor = (try cl.coordinator().findDonor(a, "main", created.generation, 0)).?;
-    try std.testing.expectEqualStrings("http://self:8080", donor.advertise_addr);
-    try std.testing.expectEqual(@as(u64, 0), donor.file_version);
+    // This is what a probing peer reads off GET /:index/_status and filters on.
+    const st = try mi.getPeerStatus("main");
+    try std.testing.expectEqual(created.generation, st.generation);
+    try std.testing.expectEqual(@as(u64, 1), st.version);
+    // No checkpoint yet, so nothing of this write is in a file segment: a snapshot
+    // from here would resume at 0, which is why file_version and not version is what
+    // donor selection keys on.
+    try std.testing.expectEqual(@as(u64, 0), st.file_version);
 
-    // collectLineageStatus reflects the applied version (1 after the update).
-    const st = try mi.collectLineageStatus(a);
-    try std.testing.expectEqual(@as(usize, 1), st.len);
-    try std.testing.expectEqualStrings("main", st[0].index_name);
-    try std.testing.expectEqual(created.generation, st[0].generation);
-    try std.testing.expectEqual(@as(u64, 1), st[0].applied);
+    try std.testing.expectError(error.IndexNotFound, mi.getPeerStatus("nope"));
 }
 
 test "bootstrapLineage swaps an index's data from a donor snapshot" {
@@ -738,8 +804,6 @@ const WedgedReads = struct {
         .createIndex = createIndexImpl,
         .deleteIndex = deleteIndexImpl,
         .readMeta = readMetaImpl,
-        .reportStatus = reportStatusImpl,
-        .findDonor = findDonorImpl,
         .setRetentionFloor = setRetentionFloorImpl,
     };
     fn appendImpl(ptr: *anyopaque, name: []const u8, generation: u64, changes: []const Change, expected: ?u64) anyerror!u64 {
@@ -762,14 +826,6 @@ const WedgedReads = struct {
     fn readMetaImpl(ptr: *anyopaque, after: u64, out: []MetaOp, deadline: zio.Timeout) anyerror!usize {
         const self: *WedgedReads = @ptrCast(@alignCast(ptr));
         return self.inner.readMeta(after, out, deadline);
-    }
-    fn reportStatusImpl(ptr: *anyopaque, status: coordinator_mod.ReplicaStatus) anyerror!void {
-        const self: *WedgedReads = @ptrCast(@alignCast(ptr));
-        return self.inner.reportStatus(status);
-    }
-    fn findDonorImpl(ptr: *anyopaque, arena: std.mem.Allocator, name: []const u8, generation: u64, after: u64) anyerror!?coordinator_mod.DonorInfo {
-        const self: *WedgedReads = @ptrCast(@alignCast(ptr));
-        return self.inner.findDonor(arena, name, generation, after);
     }
     fn setRetentionFloorImpl(ptr: *anyopaque, name: []const u8, generation: u64, floor: u64) anyerror!void {
         const self: *WedgedReads = @ptrCast(@alignCast(ptr));

--- a/src/Replicator.zig
+++ b/src/Replicator.zig
@@ -59,6 +59,14 @@ pub const default_ryw_timeout: zio.Duration = .fromMilliseconds(30_000);
 // we transfer its snapshot. Only ever waits when the answer is yes and the feed is
 // idle — BelowRetention comes back immediately — so this just bounds that idle case.
 const resume_probe: zio.Timeout = .{ .duration = .fromMilliseconds(500) };
+// Backstop for a whole snapshot transfer. A donor that accepts the connection and then
+// wedges — mid-tar, no RST — would otherwise block this consumer forever, and dusty's
+// client has no timeout of its own. Deliberately generous: a snapshot is the entire
+// index, so this must not fire on a slow-but-working transfer. It converts a hung
+// donor into "try the next one", which is what makes the ranked donor list useful.
+// NOT an idle timeout, which would be the better shape but needs a progress hook
+// through the restore reader; raise --bootstrap-timeout-ms on a slow link.
+pub const default_bootstrap_timeout: zio.Duration = .fromMilliseconds(30 * 60 * 1000);
 
 allocator: std.mem.Allocator,
 mi: *MultiIndex,
@@ -76,6 +84,7 @@ ryw_timeout: zio.Duration = default_ryw_timeout, // read/create/delete-your-writ
 peers: ?peers_mod = null,
 // Runtime io, for the snapshot fetch's HTTP client. Set by main alongside `peers`.
 io: ?std.Io = null,
+bootstrap_timeout: zio.Duration = default_bootstrap_timeout,
 
 const Consumer = struct {
     name: []const u8, // owned; also the map key
@@ -271,6 +280,25 @@ fn canResumeFrom(self: *Self, c: *Consumer, file_version: u64) !bool {
 }
 
 fn fetchFrom(self: *Self, arena: std.mem.Allocator, c: *Consumer, donor: peers_mod.Donor) !u64 {
+    // Covers the fetch AND the restore that streams the body: a donor can wedge at any
+    // point, and the restore is where most of the time goes.
+    var deadline: zio.AutoCancel = .init;
+    defer deadline.clear();
+    deadline.set(.{ .duration = self.bootstrap_timeout });
+
+    return self.fetchFromInner(arena, c, donor) catch |err| {
+        // Our own deadline, not a shutdown: report it as a donor failure so the caller
+        // moves on to the next candidate. A real cancel must stay error.Canceled and
+        // unwind the consumer.
+        if (err == error.Canceled and deadline.check(error.Canceled)) {
+            log.warn("snapshot transfer from {s} for '{s}' gen {d} timed out", .{ donor.base_url, c.name, c.generation });
+            return error.SnapshotTimeout;
+        }
+        return err;
+    };
+}
+
+fn fetchFromInner(self: *Self, arena: std.mem.Allocator, c: *Consumer, donor: peers_mod.Donor) !u64 {
     const url = try std.fmt.allocPrint(arena, "{s}/{s}/_snapshot", .{ donor.base_url, c.name });
 
     // A client per fetch: dusty's connection pool has no locking, and two indexes can
@@ -1140,4 +1168,54 @@ test "replicated delete+recreate converges on the new lineage" {
     const s2 = try mi.search(a, "main", .{ .query = &q2 });
     try std.testing.expectEqual(@as(usize, 1), s2.results.len);
     try std.testing.expectEqual(@as(u32, 2), s2.results[0].id);
+}
+
+test "a donor that wedges mid-transfer is given up on, not waited for" {
+    const MemoryCoordinator = coordinator_mod.MemoryCoordinator;
+    const common = @import("common.zig");
+
+    const rt = try zio.Runtime.init(std.testing.allocator, .{ .executors = .exact(2) });
+    defer rt.deinit();
+
+    const cwd = zio.Dir.cwd();
+    const dir_path = "test_replicator_wedged_donor";
+    common.deleteDirTree(std.testing.allocator, cwd, dir_path) catch {};
+    try cwd.createDir(dir_path, 0o755);
+    defer common.deleteDirTree(std.testing.allocator, cwd, dir_path) catch {};
+    const dir = try cwd.openDir(dir_path, .{ .iterate = true });
+
+    var cl = MemoryCoordinator.init(std.testing.allocator);
+    defer cl.deinit();
+
+    var mi = MultiIndex.init(std.testing.allocator, dir);
+    defer mi.deinit();
+    try mi.startReplication(cl.coordinator());
+
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+    const a = arena.allocator();
+
+    _ = try mi.createIndex("main", .{});
+
+    const repl = mi.replication.?;
+    repl.io = rt.io();
+    repl.bootstrap_timeout = .fromMilliseconds(300);
+    const c = repl.consumers.get("main").?;
+
+    // A listener we never accept on: the connection completes out of the backlog and
+    // the response never comes — the stall a liveness check cannot see.
+    var addr = try zio.net.IpAddress.parseIp4("127.0.0.1", 0);
+    var listener = try addr.listen(.{ .reuse_address = true });
+    defer listener.close();
+    const url = try std.fmt.allocPrint(a, "http://{f}", .{listener.socket.address.ip});
+
+    var sw = zio.Stopwatch.start();
+    const err = repl.fetchFrom(a, c, .{ .base_url = url, .file_version = 1 });
+    const elapsed_ms = @divTrunc(sw.read().toNanoseconds(), std.time.ns_per_ms);
+
+    // Reported as a donor failure, NOT error.Canceled: the caller must move on to the
+    // next candidate rather than unwinding the consumer as if we were shutting down.
+    try std.testing.expectError(error.SnapshotTimeout, err);
+    try std.testing.expect(elapsed_ms >= 250); // it really stalled
+    try std.testing.expect(elapsed_ms < 3000); // and the bound ended it
 }

--- a/src/api.zig
+++ b/src/api.zig
@@ -105,6 +105,21 @@ pub const GetIndexInfoResponse = struct {
     }
 };
 
+// What one node tells another about a lineage it holds, so a bootstrapping node can
+// pick a donor without a central registry. `file_version` is the watermark a snapshot
+// from this node would land the fetcher on (max segment version, from the manifest);
+// `version` is what it has applied, reported for observability only — a snapshot
+// carries file segments, not the tail. See peers.zig.
+pub const PeerStatusResponse = struct {
+    generation: u64,
+    version: u64,
+    file_version: u64,
+
+    pub fn msgpackFormat() msgpack.StructFormat {
+        return .{ .as_map = .{ .key = .{ .field_name_prefix = 1 } } };
+    }
+};
+
 pub const CreateIndexResponse = struct {
     version: u64,
     ready: bool,

--- a/src/coordinator_server.zig
+++ b/src/coordinator_server.zig
@@ -19,8 +19,6 @@ const ReadResponse = changelog_mod.ReadResponse;
 const MetaReadResponse = changelog_mod.MetaReadResponse;
 const MetaCreateResponse = changelog_mod.MetaCreateResponse;
 const MetaDeleteResponse = changelog_mod.MetaDeleteResponse;
-const ReplicaStatus = changelog_mod.ReplicaStatus;
-const DonorResponse = changelog_mod.DonorResponse;
 const EmptyResponse = struct {
     pub fn msgpackFormat() msgpack.StructFormat {
         return .{ .as_map = .{ .key = .{ .field_name_prefix = 1 } } };
@@ -42,8 +40,6 @@ pub fn registerRoutes(server: *Server) void {
     r.post("/_index/:index", handleCreateIndex);
     r.delete("/_index/:index", handleDeleteIndex);
     r.get("/_meta", handleReadMeta);
-    r.post("/_status", handleStatus);
-    r.get("/_donor/:index/:gen", handleDonor);
     r.post("/_truncate/:index/:gen", handleTruncate);
 }
 
@@ -54,24 +50,6 @@ fn handleTruncate(co: *Service, req: *http.Request, res: *http.Response) !void {
     co.coordinator.setRetentionFloor(index, generation, floor) catch |err|
         return fail(res, statusFor(err), @errorName(err));
     try respond(EmptyResponse{}, res);
-}
-
-fn handleStatus(co: *Service, req: *http.Request, res: *http.Response) !void {
-    const body = (req.body() catch null) orelse return fail(res, .bad_request, "missing body");
-    const status = msgpack.decodeFromSliceLeaky(ReplicaStatus, req.arena, body) catch
-        return fail(res, .bad_request, "bad body");
-    co.coordinator.reportStatus(status) catch |err|
-        return fail(res, statusFor(err), @errorName(err));
-    try respond(EmptyResponse{}, res);
-}
-
-fn handleDonor(co: *Service, req: *http.Request, res: *http.Response) !void {
-    const index = req.params.get("index") orelse return fail(res, .bad_request, "missing index");
-    const generation = genParam(req) orelse return fail(res, .bad_request, "bad generation");
-    const after = queryInt(req, "after") orelse 0;
-    const donor = co.coordinator.findDonor(req.arena, index, generation, after) catch |err|
-        return fail(res, statusFor(err), @errorName(err));
-    try respond(DonorResponse{ .donor = donor }, res);
 }
 
 fn handleCreateIndex(co: *Service, req: *http.Request, res: *http.Response) !void {

--- a/src/main.zig
+++ b/src/main.zig
@@ -52,11 +52,11 @@ const Config = struct {
     coordinator: bool = false,
     // Replica mode: consume the changelog from this coordinator URL.
     coordinator_url: ?[]const u8 = null,
-    // Base URL other nodes fetch GET /:index/_snapshot from. When set (replica mode),
-    // this node heartbeats the coordinator so it can be picked as a snapshot donor.
-    advertise_addr: ?[]const u8 = null,
-    // How often (ms) the replica heartbeats the coordinator with its lineage watermarks.
-    report_interval_ms: u64 = 5_000,
+    // Comma-separated peer base URLs ("http://host:port") to look for snapshot donors
+    // among when this node falls below the changelog's retention floor. Hostnames are
+    // re-resolved on every lookup, so a single URL naming a headless Service covers
+    // the whole cluster and follows it as pods come and go. Unset disables bootstrap.
+    peers: ?[]const u8 = null,
 };
 
 // Bulk `_update` batches (and the coordinator's append bodies, which carry the same
@@ -86,19 +86,38 @@ fn runServer(allocator: std.mem.Allocator, rt: *zio.Runtime, config: Config) !vo
         null;
     defer if (remote) |*r| r.deinit();
 
+    // Declared before the index manager so its `defer` runs after multi_index.deinit()
+    // — the replication consumers borrow these URLs until they are joined.
+    // An all-separator value ("", ",") yields no URLs; treat that as unconfigured so it
+    // takes the "cannot bootstrap" warning rather than silently claiming 0 peers.
+    const peer_urls: ?[]const []const u8 = blk: {
+        const spec = config.peers orelse break :blk null;
+        const urls = try splitPeers(allocator, spec);
+        if (urls.len == 0) {
+            allocator.free(urls);
+            break :blk null;
+        }
+        break :blk urls;
+    };
+    defer if (peer_urls) |urls| allocator.free(urls);
+
     var multi_index = MultiIndex.init(allocator, data_dir);
     multi_index.checkpoint_threshold = config.checkpoint_threshold;
     multi_index.checkpoint_age = if (config.checkpoint_age_ms == 0) null else .fromMilliseconds(config.checkpoint_age_ms);
     multi_index.load_concurrency = config.load_concurrency;
-    multi_index.advertise_addr = config.advertise_addr;
-    multi_index.report_interval = .fromMilliseconds(config.report_interval_ms);
     defer multi_index.deinit();
     try multi_index.open();
 
     if (remote) |*r| {
         try multi_index.startReplication(r.coordinator());
-        // Give the replicator an HTTP client for donor snapshot fetches on bootstrap.
-        multi_index.replication.?.http_client = http.Client.init(allocator, io, .{});
+        const repl = multi_index.replication.?;
+        repl.io = io; // for the donor snapshot fetch on bootstrap
+        if (peer_urls) |urls| {
+            repl.peers = .{ .urls = urls, .io = io, .allocator = allocator };
+            std.log.info("peer discovery over {d} configured URL(s)", .{urls.len});
+        } else {
+            std.log.warn("no --peers configured: this node cannot bootstrap from a snapshot", .{});
+        }
         std.log.info("replicating from coordinator {s}", .{config.coordinator_url.?});
     }
 
@@ -143,6 +162,20 @@ fn runServer(allocator: std.mem.Allocator, rt: *zio.Runtime, config: Config) !vo
             },
         }
     }
+}
+
+// Split a `--peers` value into base URLs. The slices point into argv, which outlives
+// the process; only the outer array is allocated.
+fn splitPeers(allocator: std.mem.Allocator, spec: []const u8) ![]const []const u8 {
+    var list: std.ArrayListUnmanaged([]const u8) = .empty;
+    errdefer list.deinit(allocator);
+    var it = std.mem.splitScalar(u8, spec, ',');
+    while (it.next()) |raw| {
+        const url = std.mem.trim(u8, raw, " \t");
+        if (url.len == 0) continue;
+        try list.append(allocator, url);
+    }
+    return list.toOwnedSlice(allocator);
 }
 
 // Run as the changelog coordinator: an HTTP server exposing append/read of an
@@ -200,10 +233,8 @@ fn parseArgs(args: std.process.Args) !Config {
             config.coordinator = true;
         } else if (std.mem.eql(u8, arg, "--coordinator-url")) {
             config.coordinator_url = it.next() orelse return error.MissingArgument;
-        } else if (std.mem.eql(u8, arg, "--advertise-addr")) {
-            config.advertise_addr = it.next() orelse return error.MissingArgument;
-        } else if (std.mem.eql(u8, arg, "--report-interval-ms")) {
-            config.report_interval_ms = try std.fmt.parseInt(u64, it.next() orelse return error.MissingArgument, 10);
+        } else if (std.mem.eql(u8, arg, "--peers")) {
+            config.peers = it.next() orelse return error.MissingArgument;
         } else {
             std.log.warn("ignoring unknown argument '{s}'", .{arg});
         }
@@ -245,4 +276,5 @@ test {
     _ = @import("coordinator_server.zig");
     _ = @import("RemoteCoordinator.zig");
     _ = @import("index_redirect.zig");
+    _ = @import("peers.zig");
 }

--- a/src/main.zig
+++ b/src/main.zig
@@ -57,6 +57,10 @@ const Config = struct {
     // re-resolved on every lookup, so a single URL naming a headless Service covers
     // the whole cluster and follows it as pods come and go. Unset disables bootstrap.
     peers: ?[]const u8 = null,
+    // Backstop for a whole snapshot transfer during bootstrap; 0 disables it. See
+    // Replicator.default_bootstrap_timeout — generous on purpose, raise it on a slow
+    // link rather than letting a wedged donor block a consumer forever.
+    bootstrap_timeout_ms: u64 = 30 * 60 * 1000,
 };
 
 // Bulk `_update` batches (and the coordinator's append bodies, which carry the same
@@ -101,6 +105,13 @@ fn runServer(allocator: std.mem.Allocator, rt: *zio.Runtime, config: Config) !vo
     };
     defer if (peer_urls) |urls| allocator.free(urls);
 
+    // Peers are only consulted when a replication consumer falls below retention, so
+    // without a coordinator they are never used. Say so rather than letting an
+    // operator believe bootstrap is configured.
+    if (peer_urls != null and remote == null) {
+        std.log.warn("--peers is set without --coordinator-url: this node is not replicating, so the peer list is unused", .{});
+    }
+
     var multi_index = MultiIndex.init(allocator, data_dir);
     multi_index.checkpoint_threshold = config.checkpoint_threshold;
     multi_index.checkpoint_age = if (config.checkpoint_age_ms == 0) null else .fromMilliseconds(config.checkpoint_age_ms);
@@ -112,6 +123,7 @@ fn runServer(allocator: std.mem.Allocator, rt: *zio.Runtime, config: Config) !vo
         try multi_index.startReplication(r.coordinator());
         const repl = multi_index.replication.?;
         repl.io = io; // for the donor snapshot fetch on bootstrap
+        if (config.bootstrap_timeout_ms != 0) repl.bootstrap_timeout = .fromMilliseconds(config.bootstrap_timeout_ms);
         if (peer_urls) |urls| {
             repl.peers = .{ .urls = urls, .io = io, .allocator = allocator };
             std.log.info("peer discovery over {d} configured URL(s)", .{urls.len});
@@ -235,6 +247,8 @@ fn parseArgs(args: std.process.Args) !Config {
             config.coordinator_url = it.next() orelse return error.MissingArgument;
         } else if (std.mem.eql(u8, arg, "--peers")) {
             config.peers = it.next() orelse return error.MissingArgument;
+        } else if (std.mem.eql(u8, arg, "--bootstrap-timeout-ms")) {
+            config.bootstrap_timeout_ms = try std.fmt.parseInt(u64, it.next() orelse return error.MissingArgument, 10);
         } else {
             std.log.warn("ignoring unknown argument '{s}'", .{arg});
         }

--- a/src/peers.zig
+++ b/src/peers.zig
@@ -1,0 +1,453 @@
+// Peer discovery for snapshot bootstrap.
+//
+// A node whose position falls below the changelog's retention floor cannot replay —
+// those positions are gone. It fetches a snapshot from a peer instead and resumes
+// from that snapshot's watermark. This module answers the only question that needs
+// answering: which peer to fetch from.
+//
+// Configuration is always a list of base URLs. Their hostnames are resolved on every
+// lookup, and a name that resolves to several addresses expands to that many peers —
+// so a Kubernetes headless Service is just one URL, and membership changes as pods
+// come and go without any config change or restart. Discovery is a *list*, never a
+// membership protocol: a bootstrapping node needs a lookup ("who has a snapshot I can
+// use"), not consensus about who is alive, so gossip and failure detection would buy
+// nothing here.
+//
+// The coordinator is deliberately not involved: it owns the log, not the nodes. A
+// registry there would make the log service stateful and therefore a singleton,
+// because two instances behind a Service each see a different subset of heartbeats.
+//
+// The other half of this protocol is `GET /:index/_status` (server.zig), which
+// reports what a node holds, and `GET /:index/_snapshot`, which serves it.
+//
+// Only cleartext http:// peers are supported: each resolved address is turned back
+// into a URL, so a hostname would not survive into the request.
+
+const std = @import("std");
+const zio = @import("zio");
+const http = @import("dusty");
+const msgpack = @import("msgpack");
+const api = @import("api.zig");
+
+const log = std.log.scoped(.peers);
+
+// Cap on addresses taken from one configured URL. Sized so the resolver can never
+// overflow it (see the lookup call below), not as a real limit on cluster size —
+// note zio's own resolver already caps a DNS answer at 8 addresses per family, so on
+// Linux that, not this, is what bounds how many peers one URL can reveal. Harmless
+// here: donor selection only needs one usable peer, not the full membership.
+pub const max_addrs_per_url = 64;
+
+// Peer URLs are rebuilt per resolved address, so only cleartext HTTP is supported.
+const http_default_port: u16 = 80;
+
+// How long one peer gets to answer a status probe before we give up on it. A peer that
+// is merely down fails fast (ECONNREFUSED); this bounds the cases that don't — a
+// black-holed address, or a peer that accepts the connection and then wedges — so one
+// sick peer can't hold up a bootstrap indefinitely. In-cluster this call is a few ms,
+// so the bound is loose on purpose: it is a backstop, not a latency target.
+pub const default_probe_timeout: zio.Duration = .fromMilliseconds(5_000);
+
+/// A peer that can serve a usable snapshot, and the watermark it would land us on.
+pub const Donor = struct {
+    base_url: []const u8, // allocated in the arena passed to findDonors
+    file_version: u64,
+};
+
+// Configured peer base URLs ("http://host:port"). Borrowed — must outlive this. Empty
+// means bootstrap is unavailable: a node that falls below retention can only wait for
+// an operator, which is fine for a single-node cluster.
+urls: []const []const u8 = &.{},
+io: std.Io,
+allocator: std.mem.Allocator,
+probe_timeout: zio.Duration = default_probe_timeout,
+
+const Self = @This();
+
+/// Expand the configured URLs into one base URL per resolved address, in `arena`.
+/// Hostnames are resolved on every call: DNS is the membership source, so a stale
+/// answer is exactly what we must avoid caching.
+pub fn resolve(self: Self, arena: std.mem.Allocator) ![]const []const u8 {
+    var out: std.ArrayListUnmanaged([]const u8) = .empty;
+    for (self.urls) |url| {
+        self.expandUrl(arena, url, &out) catch |err| {
+            // One unresolvable name must not hide the peers that did resolve.
+            log.warn("peer URL '{s}' did not resolve: {}", .{ url, err });
+        };
+    }
+    return out.toOwnedSlice(arena);
+}
+
+fn expandUrl(self: Self, arena: std.mem.Allocator, url: []const u8, out: *std.ArrayListUnmanaged([]const u8)) !void {
+    _ = self;
+    const uri = try std.Uri.parse(url);
+    // Each resolved address is turned back into a URL, so the hostname does not
+    // survive into the request — which would break TLS name verification and any
+    // Host-based routing. Rather than fail those silently (a peer that is never a
+    // donor, with only a debug line to show for it), refuse the scheme outright.
+    if (!std.mem.eql(u8, uri.scheme, "http")) return error.PeerUrlSchemeUnsupported;
+    const host_component = uri.host orelse return error.PeerUrlMissingHost;
+    const raw_host = try host_component.toRawMaybeAlloc(arena);
+    // std.Uri keeps the brackets of an IPv6 literal in the host component, and they
+    // are not part of the address — HostName rejects them.
+    const host_str = if (raw_host.len >= 2 and raw_host[0] == '[' and raw_host[raw_host.len - 1] == ']')
+        raw_host[1 .. raw_host.len - 1]
+    else
+        raw_host;
+    const port = uri.port orelse http_default_port;
+
+    // HostName accepts a numeric address as well as a name, and lookup resolves it to
+    // itself — so a literal-IP peer needs no special case here.
+    const host = try zio.net.HostName.init(host_str);
+    var storage: [max_addrs_per_url]zio.net.HostName.LookupResult = undefined;
+    // Deliberately NOT `catch error.TooManyAddresses => storage.len`. How much of
+    // `storage` is valid on that error depends on which resolver answered: the
+    // getaddrinfo path documents "the buffer is fully populated" (dns/posix.zig), but
+    // the custom resolver's DNS path returns before its copy-back
+    // (dns/resolver/resolver.zig:352), leaving `storage` untouched. Since `lookup`
+    // returns no count on error, there is no way to tell — so don't guess.
+    //
+    // Unreachable in practice at this size, which is the point of sizing it here:
+    // zio's custom resolver caps answers at 8 addresses per family (silently — see
+    // `@min(result.count, parse_addrs.len)` at resolver.zig:718), and the paths that
+    // can exceed 64 fill before erroring anyway.
+    const n = try host.lookup(&storage, .{ .port = port });
+
+    for (storage[0..n]) |entry| switch (entry) {
+        // IpAddress.format renders host:port, bracketing IPv6.
+        .address => |addr| try out.append(arena, try std.fmt.allocPrint(arena, "http://{f}", .{addr})),
+        .canonical_name => {},
+    };
+}
+
+// One peer's probe slot. `ok` stays false on any failure — an unreachable or
+// mid-restart peer is not an error, it just isn't a donor.
+const Probe = struct {
+    base_url: []const u8,
+    ok: bool = false,
+    generation: u64 = 0,
+    file_version: u64 = 0,
+};
+
+/// Every peer able to donate a snapshot of (`index_name`, `generation`) to a consumer
+/// stuck at `after`, freshest first. Empty if none can. Probes all peers concurrently.
+///
+/// A *ranked* list rather than one pick: the best peer's `_snapshot` can still fail
+/// (it may be mid-bootstrap itself, or its disk may be failing), and re-probing would
+/// only rank it first again — one sick-but-freshest peer would wedge bootstrap
+/// indefinitely. The caller walks the list instead.
+pub fn findDonors(
+    self: Self,
+    arena: std.mem.Allocator,
+    index_name: []const u8,
+    generation: u64,
+    after: u64,
+) ![]const Donor {
+    const urls = try self.resolve(arena);
+    if (urls.len == 0) {
+        log.warn("no peers resolved for '{s}': cannot bootstrap", .{index_name});
+        return &.{};
+    }
+
+    const probes = try arena.alloc(Probe, urls.len);
+    for (probes, urls) |*p, url| p.* = .{ .base_url = url };
+
+    // Probe concurrently, each bounded by its own AutoCancel: a sick peer costs the
+    // fan-out one probe_timeout, not a serial one each, and never an unbounded stall.
+    var group: zio.Group = .init;
+    errdefer group.cancel();
+    for (probes) |*p| try group.spawn(probeOne, .{ self.io, self.allocator, index_name, self.probe_timeout, p });
+    try group.wait();
+
+    const donors = try rankDonors(arena, probes, generation, after);
+    // Bootstrap only runs during an incident, so say enough to diagnose one: without
+    // this, "no donor" is indistinguishable from DNS returning nothing, every peer
+    // refusing, a generation mismatch, or every peer simply being too far behind.
+    if (donors.len == 0) {
+        var answered: usize = 0;
+        var best_seen: u64 = 0;
+        for (probes) |p| {
+            if (!p.ok) continue;
+            answered += 1;
+            if (p.generation == generation and p.file_version > best_seen) best_seen = p.file_version;
+        }
+        log.warn(
+            "no donor for '{s}' gen {d} at {d}: {d}/{d} peers answered, best usable file_version {d}",
+            .{ index_name, generation, after, answered, probes.len, best_seen },
+        );
+    }
+    return donors;
+}
+
+/// The selection rule, split out from the I/O so it can be tested directly.
+///
+/// Requiring `file_version > after` does two things at once: it guarantees forward
+/// progress (a snapshot at or below where we already are would re-trigger the same
+/// below-retention read), and it excludes this node from its own peer list for free —
+/// a node's `file_version` never exceeds its applied version, and `after` IS that
+/// applied version, so a bootstrapping node can never rank itself. That is why no node
+/// identity or self-address configuration is needed anywhere.
+///
+/// Freshest first: the highest `file_version` has the best chance of clearing a
+/// retention floor we cannot see. If it doesn't clear it, the next read re-signals and
+/// we try again from further along, so the loop still converges.
+fn rankDonors(arena: std.mem.Allocator, probes: []const Probe, generation: u64, after: u64) ![]const Donor {
+    var list: std.ArrayListUnmanaged(Donor) = .empty;
+    for (probes) |p| {
+        if (!p.ok) continue;
+        if (p.generation != generation) continue; // different lineage, not our data
+        if (p.file_version <= after) continue; // no progress (excludes ourselves)
+        try list.append(arena, .{ .base_url = p.base_url, .file_version = p.file_version });
+    }
+    const donors = try list.toOwnedSlice(arena);
+    std.mem.sort(Donor, donors, {}, struct {
+        fn desc(_: void, a: Donor, b: Donor) bool {
+            return a.file_version > b.file_version;
+        }
+    }.desc);
+    return donors;
+}
+
+// Ask one peer what it holds for `index_name`. Errors are swallowed by design: this
+// runs against every configured peer, and peers being down is the normal case this
+// whole mechanism exists to survive.
+//
+// The AutoCancel bounds every suspension point in the probe, connect and read alike, by
+// canceling this task's I/O when it fires. `check` is what separates our own deadline
+// from a real shutdown cancel — the latter must stay quiet and let the group unwind.
+fn probeOne(io: std.Io, allocator: std.mem.Allocator, index_name: []const u8, timeout: zio.Duration, p: *Probe) void {
+    var deadline: zio.AutoCancel = .init;
+    defer deadline.clear();
+    deadline.set(.{ .duration = timeout });
+
+    var arena = std.heap.ArenaAllocator.init(allocator);
+    defer arena.deinit();
+    const a = arena.allocator();
+
+    probeOneFallible(io, a, index_name, p) catch |err| {
+        if (err == error.Canceled) {
+            if (!deadline.check(error.Canceled)) return; // shutdown, not our deadline
+            log.debug("peer {s} timed out for '{s}'", .{ p.base_url, index_name });
+            return;
+        }
+        log.debug("peer {s} did not answer for '{s}': {}", .{ p.base_url, index_name, err });
+    };
+}
+
+fn probeOneFallible(io: std.Io, arena: std.mem.Allocator, index_name: []const u8, p: *Probe) !void {
+    const url = try std.fmt.allocPrint(arena, "{s}/{s}/_status", .{ p.base_url, index_name });
+
+    // A client per probe: they run concurrently and dusty's connection pool is not
+    // shared-safe. Same pattern as RemoteCoordinator's per-call clients.
+    var client = http.Client.init(arena, io, .{});
+    defer client.deinit();
+
+    // Without an Accept header the server answers a bodyless GET in JSON.
+    var headers = try http.Headers.init(arena, 1);
+    defer headers.deinit(arena);
+    try headers.add("Accept", comptime http.ContentType.msgpack.toContentType());
+
+    var resp = try client.fetch(url, .{ .method = .get, .headers = &headers });
+    defer resp.deinit();
+    // 404 is routine: the peer simply doesn't hold this index yet.
+    if (resp.status() != .ok) return error.PeerStatusFailed;
+
+    const body = (try resp.body()) orelse return error.EmptyPeerStatus;
+    const status = try msgpack.decodeFromSliceLeaky(api.PeerStatusResponse, arena, body);
+
+    p.generation = status.generation;
+    p.file_version = status.file_version;
+    p.ok = true;
+}
+
+const testing = std.testing;
+
+// Resolution needs a runtime: zio's resolver suspends, and HostName.lookup must run
+// on a coroutine. Literal addresses still go through it, which is the point — one
+// code path for names and IPs.
+fn testResolve(urls: []const []const u8, out: *[]const []const u8, arena: std.mem.Allocator, err: *?anyerror) void {
+    const self: Self = .{ .urls = urls, .io = undefined, .allocator = testing.allocator };
+    out.* = self.resolve(arena) catch |e| {
+        err.* = e;
+        return;
+    };
+}
+
+fn resolveInRuntime(urls: []const []const u8, arena: std.mem.Allocator) ![]const []const u8 {
+    const rt = try zio.Runtime.init(testing.allocator, .{ .executors = .exact(1) });
+    defer rt.deinit();
+
+    var out: []const []const u8 = &.{};
+    var err: ?anyerror = null;
+    var task = try zio.spawn(testResolve, .{ urls, &out, arena, &err });
+    task.join();
+    if (err) |e| return e;
+    return out;
+}
+
+test "resolve expands literal addresses, keeping scheme and port" {
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+
+    const urls = try resolveInRuntime(&.{ "http://127.0.0.1:8080", "http://[::1]:9090" }, arena.allocator());
+    try testing.expectEqual(@as(usize, 2), urls.len);
+    try testing.expectEqualStrings("http://127.0.0.1:8080", urls[0]);
+    try testing.expectEqualStrings("http://[::1]:9090", urls[1]);
+}
+
+test "resolve defaults the port from the scheme" {
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+
+    const urls = try resolveInRuntime(&.{"http://127.0.0.1"}, arena.allocator());
+    try testing.expectEqual(@as(usize, 1), urls.len);
+    try testing.expectEqualStrings("http://127.0.0.1:80", urls[0]);
+}
+
+test "resolve skips a bad URL rather than losing the peers that did resolve" {
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+
+    // "not a url" has no host; the literal after it must still come through.
+    const urls = try resolveInRuntime(&.{ "not a url", "http://127.0.0.1:8080" }, arena.allocator());
+    try testing.expectEqual(@as(usize, 1), urls.len);
+    try testing.expectEqualStrings("http://127.0.0.1:8080", urls[0]);
+}
+
+test "no peers configured resolves to nothing" {
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+
+    const urls = try resolveInRuntime(&.{}, arena.allocator());
+    try testing.expectEqual(@as(usize, 0), urls.len);
+}
+
+test "resolve refuses https, which cannot survive the rebuild from an address" {
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+
+    // Silently dropping it would leave a peer that is never a donor and no clue why.
+    const urls = try resolveInRuntime(&.{ "https://127.0.0.1:8443", "http://127.0.0.1:8080" }, arena.allocator());
+    try testing.expectEqual(@as(usize, 1), urls.len);
+    try testing.expectEqualStrings("http://127.0.0.1:8080", urls[0]);
+}
+
+// --- donor selection (the rule both design claims rest on) ---
+
+fn probe(url: []const u8, generation: u64, file_version: u64) Probe {
+    return .{ .base_url = url, .ok = true, .generation = generation, .file_version = file_version };
+}
+
+test "rankDonors returns usable donors, freshest first" {
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+
+    const probes = [_]Probe{
+        probe("http://a", 1, 5),
+        probe("http://b", 1, 9),
+        probe("http://c", 1, 7),
+    };
+    const donors = try rankDonors(arena.allocator(), &probes, 1, 0);
+    try testing.expectEqual(@as(usize, 3), donors.len);
+    try testing.expectEqualStrings("http://b", donors[0].base_url);
+    try testing.expectEqualStrings("http://c", donors[1].base_url);
+    try testing.expectEqualStrings("http://a", donors[2].base_url);
+}
+
+test "rankDonors drops peers that cannot help" {
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+
+    const probes = [_]Probe{
+        .{ .base_url = "http://silent", .ok = false, .generation = 1, .file_version = 99 },
+        probe("http://wrong-lineage", 2, 99), // delete+recreate: not our data
+        probe("http://behind", 1, 4), // at or below where we're stuck: no progress
+        probe("http://equal", 1, 5),
+        probe("http://good", 1, 6),
+    };
+    const donors = try rankDonors(arena.allocator(), &probes, 1, 5);
+    try testing.expectEqual(@as(usize, 1), donors.len);
+    try testing.expectEqualStrings("http://good", donors[0].base_url);
+}
+
+test "rankDonors excludes the bootstrapping node itself" {
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+
+    // A node's file_version never exceeds its applied version, and `after` IS that
+    // applied version — so its own probe can never satisfy `file_version > after`.
+    // This is what makes self-address configuration unnecessary; if the comparison
+    // were ever loosened to >=, a node could "bootstrap" from itself and spin.
+    const after: u64 = 12;
+    const probes = [_]Probe{probe("http://self", 1, after)};
+    const donors = try rankDonors(arena.allocator(), &probes, 1, after);
+    try testing.expectEqual(@as(usize, 0), donors.len);
+}
+
+test "a peer that accepts but never answers is given up on, not waited for" {
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const a = arena.allocator();
+
+    const rt = try zio.Runtime.init(testing.allocator, .{ .executors = .exact(2) });
+    defer rt.deinit();
+
+    const Ctx = struct {
+        io: std.Io,
+        url: []const u8 = &.{},
+        arena: std.mem.Allocator,
+        elapsed_ms: u64 = 0,
+        donors: []const Donor = &.{},
+        err: ?anyerror = null,
+
+        fn run(ctx: *@This()) void {
+            // A listening socket we never accept on: connect() completes out of the
+            // backlog, then the HTTP response never comes. This is the stall that a
+            // plain "is the peer up?" check cannot catch.
+            var server = zio.net.IpAddress.parseIp4("127.0.0.1", 0) catch |e| {
+                ctx.err = e;
+                return;
+            };
+            var listener = server.listen(.{ .reuse_address = true }) catch |e| {
+                ctx.err = e;
+                return;
+            };
+            defer listener.close();
+            // bind() writes the actually-bound address back, so port 0 resolves here.
+            const bound = listener.socket.address.ip;
+
+            const url = std.fmt.allocPrint(ctx.arena, "http://{f}", .{bound}) catch |e| {
+                ctx.err = e;
+                return;
+            };
+            ctx.url = url;
+
+            const urls = [_][]const u8{url};
+            const peers: Self = .{
+                .urls = &urls,
+                .io = ctx.io,
+                .allocator = testing.allocator,
+                .probe_timeout = .fromMilliseconds(300),
+            };
+
+            var sw = zio.Stopwatch.start();
+            ctx.donors = peers.findDonors(ctx.arena, "main", 1, 0) catch |e| {
+                ctx.err = e;
+                return;
+            };
+            ctx.elapsed_ms = @intCast(@divTrunc(sw.read().toNanoseconds(), std.time.ns_per_ms));
+        }
+    };
+
+    var ctx: Ctx = .{ .io = rt.io(), .arena = a };
+    var task = try zio.spawn(Ctx.run, .{&ctx});
+    task.join();
+
+    if (ctx.err) |e| return e;
+    try testing.expectEqual(@as(usize, 0), ctx.donors.len);
+    // It really stalled — the connect succeeded out of the backlog and the read hung,
+    // so anything near-instant would mean the test wasn't exercising the timeout.
+    try testing.expect(ctx.elapsed_ms >= 250);
+    // And the stall was ended by probe_timeout, not by the OS read timeout (minutes).
+    try testing.expect(ctx.elapsed_ms < 3000);
+}

--- a/src/server.zig
+++ b/src/server.zig
@@ -32,6 +32,7 @@ pub fn registerRoutes(server: *Server) void {
     r.delete("/:index", handleDeleteIndex);
 
     r.get("/:index/_snapshot", handleSnapshotExport);
+    r.get("/:index/_status", handlePeerStatus);
 }
 
 // --- helpers ---
@@ -291,6 +292,14 @@ const ChunkedWriter = struct {
         return w.consume(total);
     }
 };
+
+// What this node holds for an index, so a bootstrapping peer can decide whether to
+// fetch a snapshot from here. The peer-facing half of peers.findDonor; deliberately
+// cheap, since every bootstrapping node probes every peer.
+fn handlePeerStatus(mi: *MultiIndex, req: *http.Request, res: *http.Response) !void {
+    const response = mi.getPeerStatus(indexName(req)) catch |err| return sendError(req, res, err);
+    try respond(response, req, res);
+}
 
 fn handleSnapshotExport(mi: *MultiIndex, req: *http.Request, res: *http.Response) !void {
     // Acquire the pinned snapshot first: this is the only step that can fail before any

--- a/tests/test_cluster.py
+++ b/tests/test_cluster.py
@@ -171,92 +171,33 @@ def test_index_delete_and_recreate_converges(cluster):
     assert _search_has(p1, [7, 8, 9], 9)
 
 
-def test_coordinator_registry_endpoints(cluster):
-    """POST /_status and GET /_donor on the coordinator (msgpack). The replica
-    reporter (milestone 3c) and bootstrap (4) drive these end-to-end later."""
-    import msgpack
+def test_peer_status_endpoint(cluster):
+    """GET /:index/_status is the whole peer-facing protocol: what a probing node
+    reads to decide whether this one can donate a snapshot."""
+    _co, p1, _p2 = cluster
 
-    co, _p1, _p2 = cluster
+    # Unknown index -> 404, so a peer that doesn't hold it simply isn't a donor.
+    with pytest.raises(urllib.error.HTTPError) as exc:
+        _req(p1, "GET", "/nope/_status")
+    assert exc.value.code == 404
 
-    def get_donor(after):
-        r = urllib.request.urlopen(
-            f"http://127.0.0.1:{co}/_donor/main/1?after={after}", timeout=5
-        )
-        return msgpack.unpackb(r.read(), raw=False)
+    _req(p1, "PUT", "/main")
+    assert _wait_index(p1, "main")
+    _req(p1, "PUT", "/main/1", {"hashes": [10, 20, 30]})
+    assert _search_has(p1, [10, 20, 30], 1)
 
-    # Nobody has reported yet -> DonorResponse{donor:null} (omit_nulls -> empty map).
-    assert get_donor(0).get("d") is None
-
-    # A replica holding (main, gen 1) checkpointed at file_version 5 (prefix keys:
-    # r=replica_id a=advertise_addr l=lineages; i=index_name g=generation a=applied
-    # f=file_version).
-    status = {
-        "r": "rX",
-        "a": "http://127.0.0.1:9999",
-        "l": [{"i": "main", "g": 1, "a": 10, "f": 5}],
-    }
-    req = urllib.request.Request(
-        f"http://127.0.0.1:{co}/_status", data=msgpack.packb(status), method="POST"
-    )
-    assert urllib.request.urlopen(req, timeout=5).status == 200
-
-    # A reader at/below the watermark gets rX; past it, no donor.
-    d = get_donor(0)["d"]
-    assert d["a"] == "http://127.0.0.1:9999"
-    assert d["f"] == 5
-    assert get_donor(10).get("d") is None
-
-
-def test_replica_status_reporter_registers_donor(tmp_path):
-    """End-to-end reporter path: a replica with --advertise-addr heartbeats the
-    coordinator, which can then hand it back as a snapshot donor."""
-    import msgpack
-
-    if not os.path.exists(BINARY):
-        subprocess.run(["zig", "build"], cwd=REPO_ROOT, check=True)
-
-    co, p1 = _free_port(), _free_port()
-    procs = []
-
-    def start(args):
-        procs.append(subprocess.Popen([BINARY] + args))
-
-    try:
-        start(["--coordinator", "--port", str(co)])
-        _wait(co, "/_changelog/x/1?after=0&max=1&timeout_ms=50")
-        url = f"http://127.0.0.1:{co}"
-        addr = f"http://127.0.0.1:{p1}"
-        start(["--port", str(p1), "--dir", str(tmp_path / "r1"), "--coordinator-url", url,
-               "--advertise-addr", addr, "--report-interval-ms", "200"])
-        _wait(p1, "/_health")
-
-        _req(p1, "PUT", "/main")  # first index -> generation 1
-
-        def donor():
-            r = urllib.request.urlopen(f"http://127.0.0.1:{co}/_donor/main/1?after=0", timeout=5)
-            return msgpack.unpackb(r.read(), raw=False).get("d")
-
-        found = None
-        deadline = time.time() + 10
-        while time.time() < deadline:
-            found = donor()
-            if found is not None:
-                break
-            time.sleep(0.1)
-        assert found is not None, "replica never registered as a donor"
-        assert found["a"] == addr
-    finally:
-        for p in procs:
-            p.send_signal(signal.SIGKILL)
-        for p in procs:
-            p.wait()
+    st = _req(p1, "GET", "/main/_status")
+    assert st["generation"] >= 1
+    assert st["version"] >= 1
+    # Nothing checkpointed yet, so a snapshot from here resumes at 0. Donor selection
+    # keys on file_version rather than version for exactly this reason.
+    assert st["file_version"] == 0
 
 
 def test_new_node_bootstraps_from_peer(tmp_path):
     """A new node joins after the changelog is truncated past position 0: it can't
-    replay from scratch, so it fetches a snapshot from a live peer and resumes."""
-    import msgpack
-
+    replay from scratch, so it finds a donor among its configured peers, fetches a
+    snapshot and resumes from its watermark."""
     if not os.path.exists(BINARY):
         subprocess.run(["zig", "build"], cwd=REPO_ROOT, check=True)
 
@@ -266,9 +207,11 @@ def test_new_node_bootstraps_from_peer(tmp_path):
     def start(args):
         procs.append(subprocess.Popen([BINARY] + args))
 
-    def donor(after):
-        r = urllib.request.urlopen(f"http://127.0.0.1:{co}/_donor/main/1?after={after}", timeout=5)
-        return msgpack.unpackb(r.read(), raw=False).get("d")
+    def file_version(port):
+        try:
+            return _req(port, "GET", "/main/_status")["file_version"]
+        except Exception:
+            return 0
 
     try:
         start(["--coordinator", "--port", str(co)])
@@ -276,29 +219,31 @@ def test_new_node_bootstraps_from_peer(tmp_path):
         url = f"http://127.0.0.1:{co}"
 
         # r1 checkpoints each update (threshold 1) so it holds donatable file segments.
-        a1 = f"http://127.0.0.1:{p1}"
         start(["--port", str(p1), "--dir", str(tmp_path / "r1"), "--coordinator-url", url,
-               "--advertise-addr", a1, "--report-interval-ms", "200", "--checkpoint-threshold", "1"])
+               "--checkpoint-threshold", "1"])
         _wait(p1, "/_health")
         _req(p1, "PUT", "/main")
         _req(p1, "PUT", "/main/1", {"hashes": [10, 20, 30]})
         _req(p1, "PUT", "/main/2", {"hashes": [40, 50, 60]})
         assert _search_has(p1, [10, 20, 30], 1)
 
-        # Wait until r1 has checkpointed and advertised a donatable watermark.
+        # Wait until r1 has checkpointed, i.e. holds a segment worth donating.
         deadline = time.time() + 10
-        while time.time() < deadline and donor(1) is None:
+        while time.time() < deadline and file_version(p1) < 1:
             time.sleep(0.1)
-        assert donor(1) is not None, "r1 never advertised a donatable segment"
+        assert file_version(p1) >= 1, "r1 never checkpointed a donatable segment"
 
         # Truncate the changelog below r1's watermark: a fresh consumer at 0 must bootstrap.
         req = urllib.request.Request(f"http://127.0.0.1:{co}/_truncate/main/1?floor=1", method="POST")
         assert urllib.request.urlopen(req, timeout=5).status == 200
 
-        # New node joins: it can't replay from 0 (truncated) -> bootstraps from r1.
-        a2 = f"http://127.0.0.1:{p2}"
+        # New node joins: it can't replay from 0 (truncated), so it probes its peer
+        # list. r2 is in its own list on purpose — it must not pick itself, though
+        # note the unit tests in src/peers.zig are what actually pin that rule down
+        # (here r1 would win on freshness regardless).
+        peers = f"http://127.0.0.1:{p1},http://127.0.0.1:{p2}"
         start(["--port", str(p2), "--dir", str(tmp_path / "r2"), "--coordinator-url", url,
-               "--advertise-addr", a2, "--report-interval-ms", "200"])
+               "--peers", peers])
         _wait(p2, "/_health")
         assert _wait_index(p2, "main")
         assert _search_has(p2, [10, 20, 30], 1)


### PR DESCRIPTION
Replaces the coordinator-side replica registry with peer discovery on the nodes themselves.

## Why

The registry made the log implementation **stateful, and therefore a singleton**. Replicas heartbeated `POST /_status`, and the coordinator kept an in-memory `replica_id -> {addr, last_seen, watermarks}` table that answered `GET /_donor`. Run two instances behind a Service and each sees a different subset of the heartbeats: they disagree about who can donate, and each computes retention from a partial view. Keeping it would have meant moving heartbeats into PG — a write per replica every few seconds, on the primary, purely for liveness. The log half is otherwise stateless and horizontally scalable, and this welded it to something that isn't.

## What replaces it

```
--peers http://a:8080,http://b:8080     # or one headless-Service URL

GET /:index/_status    -> { generation, version, file_version }
GET /:index/_snapshot  -> tar (unchanged)
```

Hostnames are re-resolved on **every** donor lookup, so one URL naming a headless Service expands to every ready pod and tracks the cluster as pods come and go — no config change, no restart. This is a lookup, not a membership protocol: a bootstrapping node needs to know who holds a usable snapshot, not who is alive, so there is nothing to gossip about.

**Selection is `file_version > after`, strictly greater.** That single condition guarantees forward progress (a snapshot at or below where we are stuck would re-trigger the same below-retention read) *and* excludes a node from its own peer list for free, since `file_version` never exceeds the applied version and `after` is that applied version. So there is no node identity and no advertise address anywhere in the config.

**Candidates are vetted against the log before any transfer.** A snapshot only helps if the tail above its watermark is still retained, and only the log knows its own floor — so we do a short read at that position first. The retention check runs before the feed blocks, so it answers immediately. Candidates are ranked freshest-first and the floor is common to all of them, so a failure on the first means every one is too old; that reports the cluster as unable to self-heal rather than thrashing full index transfers to find out.

**Probes are concurrent and individually bounded** by a `zio.AutoCancel`, so a peer that accepts a connection and then wedges costs the fan-out one timeout instead of hanging it. The ranked list is walked on *serve* failures (donor mid-bootstrap itself, failing disk, reset mid-tar), which would otherwise let one sick-but-freshest peer wedge bootstrap permanently.

## Review follow-ups (second commit)

**The snapshot transfer is now bounded too.** The probes were already under a `zio.AutoCancel`; the transfer they lead to was not, which left the hole open on the path that matters — a donor can accept the connection and then wedge mid-tar, and dusty's client has no timeout of its own. `fetchFrom` now runs under its own deadline covering both the fetch and the restore that streams the body.

The timeout maps to `error.SnapshotTimeout` rather than propagating `error.Canceled`: a shutdown must unwind the consumer, but our own deadline is a *donor* failure and the caller has to be free to try the next candidate. That distinction is what makes the ranked list worth having — a wedged freshest peer no longer wedges bootstrap.

The bound is deliberately generous (30 min, `--bootstrap-timeout-ms`, 0 disables) because a snapshot is the whole index and it must not fire on a slow-but-working transfer. An idle timeout would be the better shape but needs a progress hook through the restore reader; noted in place rather than faked.

**`--peers` without `--coordinator-url` now warns** — peers are only consulted when a consumer falls below retention, so on a non-replicating node the list is silently unused.

## Removed

`reportStatus`/`findDonor` from the `Coordinator` vtable; the `ReplicaStatus`/`LineageStatus`/`DonorInfo`/`DonorResponse` wire types; the `MemoryCoordinator` replica table and liveness timeout; `POST /_status` and `GET /_donor` on the coordinator server; the replica status-reporter coroutine; `--advertise-addr` and `--report-interval-ms`.

## Deployment notes

- **Only cleartext `http://` peers are supported**, and other schemes are refused with a clear error. Each resolved address is turned back into a URL, so a hostname does not survive into the request — which would break TLS name verification and Host-based routing. Failing loudly beats a peer that silently never becomes a donor.
- **Readiness must mean "index open and serving", not "caught up with the log."** A headless Service publishes only Ready endpoints, so if readiness required being caught up, a cold cluster restart would deadlock: nobody ready, DNS empty, no donor, nobody becomes ready. Filter unsuitable donors on what `_status` reports, never via DNS.

## Not covered

- **Retention in the log implementation still has to become time-based.** It can no longer key on `min(file_version)` across live replicas, because the log no longer knows the replicas. That is safe precisely because bootstrap works — falling off the log becomes recoverable rather than fatal, which demotes retention from a correctness mechanism to a tuning knob — but it is not implemented here. Tracked as a milestone in `notes/bootstrap-design.md`.
- A bootstrap that succeeds but still lands below a floor that moved during the transfer re-loops without extra backoff. Now rare rather than routine, given the pre-transfer check; bounded because each round strictly advances.
- `notes/bootstrap-design.md` is updated where it directly contradicted the code; the rest of that document was not revised.

## Testing

- `zig build unit-tests` — **84/84 pass** (78 before, plus 6 new covering donor ranking and rejection, self-exclusion, the pre-transfer retention check, https refusal, a peer that accepts but never answers, and a donor that wedges mid-transfer being given up on as a donor failure rather than a cancel).
- `zig build e2e-tests` — **47/47 pass**. Was 48: two coordinator-registry tests were replaced by one covering `GET /:index/_status`. `test_new_node_bootstraps_from_peer` exercises the full path — truncate the changelog below a live peer's watermark, start a new node, and it discovers the donor, fetches, and resumes.
- `zig fmt --check src/` clean.
