### PR TITLE
Separate the log position from the internal commit id

### DIFF
--- a/src/FileSegment.zig
+++ b/src/FileSegment.zig
@@ -62,7 +62,7 @@ pub fn init(allocator: std.mem.Allocator) Self {
 pub fn deinit(self: *Self) void {
     if (self.delete_on_destroy and self.data.len > 0) {
         var buf: [64]u8 = undefined;
-        const name = std.fmt.bufPrint(&buf, "{x:0>16}-{x:0>8}.data", .{ self.info.version, self.info.merges }) catch unreachable;
+        const name = std.fmt.bufPrint(&buf, "{x:0>16}-{x:0>8}.data", .{ self.info.commit_id, self.info.merges }) catch unreachable;
         self.dir.deleteFile(name) catch |err| {
             if (err != error.FileNotFound) log.warn("failed to delete segment file {s}: {}", .{ name, err });
         };
@@ -165,7 +165,7 @@ pub fn search(self: Self, sorted_hashes: []const u32, results: *SearchResults) !
 
             const matched = block_reader.searchHash(hash);
             for (matched) |docid| {
-                try results.incr(docid, self.info.version);
+                try results.incr(docid, self.info.commit_id);
             }
 
             num_blocks += 1;

--- a/src/Index.zig
+++ b/src/Index.zig
@@ -46,6 +46,9 @@ pub const Segments = struct {
     // this index resumes from (it carries file segments only). See SegmentInfo.
     version: u64 = 0,
     file_version: u64 = 0,
+    // Whether this index is fed by an upstream log; rides along so a snapshot taken
+    // from this reader carries it to whoever restores it. See Oplog.append.
+    external_versions: bool = false,
 
     // Drop every segment ref. A file whose last reference this releases is deleted
     // iff the segment was retired by a merge (FileSegment.delete_on_destroy) — so
@@ -268,7 +271,8 @@ pub fn open(allocator: std.mem.Allocator, dir: zio.Dir, checkpoint_threshold: us
     //    slot, so results stay in manifest order.
     var file_commit_id: u64 = 0;
     var file_version: u64 = 0;
-    const infos = try manifest.read(data_dir, allocator);
+    const loaded = try manifest.read(data_dir, allocator);
+    const infos = loaded.segments;
     defer allocator.free(infos);
 
     const refs = try allocator.alloc(FileRef, infos.len);
@@ -321,6 +325,11 @@ pub fn open(allocator: std.mem.Allocator, dir: zio.Dir, checkpoint_threshold: us
     var ctx = ReplayCtx{ .allocator = allocator, .mem_list = &mem_list, .file_commit_id = file_commit_id };
     var oplog = try Oplog.open(allocator, oplog_dir, sync, &ctx, ReplayCtx.apply);
     errdefer oplog.deinit();
+    // Replay only sees transactions still in the WAL, and a checkpoint truncates it —
+    // so the sticky marker has to come back from the manifest too, or an index whose
+    // data is fully checkpointed would forget it had an upstream and start minting
+    // local versions on top of upstream ones.
+    if (loaded.external_versions) oplog.external_versions = true;
 
     const commit_id = @max(file_commit_id, oplog.last_commit_id);
     // The resume point: the newest position durable anywhere, in file segments or in
@@ -336,6 +345,7 @@ pub fn open(allocator: std.mem.Allocator, dir: zio.Dir, checkpoint_threshold: us
         .file_commit_id = file_commit_id,
         .version = version,
         .file_version = file_version,
+        .external_versions = oplog.external_versions,
     });
 
     return .{
@@ -432,6 +442,7 @@ fn createSnapshot(self: *Self, file: []FileRef, memory: []MemoryRef, w: Watermar
         .file_commit_id = w.file_commit_id,
         .version = w.version,
         .file_version = w.file_version,
+        .external_versions = self.oplog.external_versions,
     });
 }
 
@@ -932,7 +943,11 @@ fn writeManifestFor(self: *Self, file: []const FileRef) !void {
     const infos = try self.allocator.alloc(SegmentInfo, file.len);
     defer self.allocator.free(infos);
     for (file, 0..) |seg, i| infos[i] = seg.value.info;
-    try manifest.write(self.data_dir, self.allocator, infos);
+    try manifest.write(self.data_dir, self.allocator, .{
+        .segments = infos,
+        // Carried across checkpoints: the oplog that recorded it is truncated.
+        .external_versions = self.oplog.external_versions,
+    });
 }
 
 fn cleanupTestDir(cwd: zio.Dir, path: []const u8) void {
@@ -1654,4 +1669,95 @@ test "version survives checkpoint and restart, and drives the donor watermark" {
         defer reader.deinit();
         try std.testing.expectEqual(@as(u64, 5000), reader.getDocInfo(99).?.version);
     }
+}
+
+test "versions never go backwards, and an upstream-fed index stays upstream-fed" {
+    const rt = try zio.Runtime.init(std.testing.allocator, .{});
+    defer rt.deinit();
+
+    const cwd = zio.Dir.cwd();
+    const dir_path = "test_index_version_monotonic";
+    cleanupTestDir(cwd, dir_path);
+    try cwd.createDir(dir_path, 0o755);
+    defer cleanupTestDir(cwd, dir_path);
+
+    {
+        const dir = try cwd.openDir(dir_path, .{ .iterate = true });
+        var index = try Self.open(std.testing.allocator, dir, 100_000, true, null);
+        defer index.deinit();
+
+        _ = try index.update(&[_]Change{.{ .insert = .{ .id = 1, .hashes = &[_]u32{1} } }}, .{ .version = 500 });
+
+        // Backwards is refused and writes nothing.
+        try std.testing.expectError(error.VersionWentBackwards, index.update(
+            &[_]Change{.{ .insert = .{ .id = 2, .hashes = &[_]u32{2} } }},
+            .{ .version = 499 },
+        ));
+        try std.testing.expectEqual(@as(u64, 500), index.version);
+        try std.testing.expectEqual(@as(u64, 1), index.commit_id);
+
+        // Equal is allowed: a bootstrap loads a whole snapshot taken at one position,
+        // so many commits legitimately share it.
+        _ = try index.update(&[_]Change{.{ .insert = .{ .id = 3, .hashes = &[_]u32{3} } }}, .{ .version = 500 });
+        try std.testing.expectEqual(@as(u64, 500), index.version);
+        try std.testing.expectEqual(@as(u64, 2), index.commit_id);
+
+        // And a positionless write is now refused outright: minting a local version on
+        // top of upstream ones would invent a position the upstream never issued.
+        try std.testing.expectError(error.VersionRequired, index.update(
+            &[_]Change{.{ .insert = .{ .id = 4, .hashes = &[_]u32{4} } }},
+            .{},
+        ));
+    }
+
+    // The marker is sticky across a restart.
+    {
+        const dir = try cwd.openDir(dir_path, .{ .iterate = true });
+        var index = try Self.open(std.testing.allocator, dir, 1, true, null);
+        defer index.deinit();
+        try std.testing.expectError(error.VersionRequired, index.update(
+            &[_]Change{.{ .insert = .{ .id = 5, .hashes = &[_]u32{5} } }},
+            .{},
+        ));
+
+        // Checkpoint everything, which truncates the WAL that carried the marker...
+        _ = try index.update(&[_]Change{.{ .insert = .{ .id = 6, .hashes = &[_]u32{6} } }}, .{ .version = 900 });
+        var i: usize = 0;
+        while (i < 5) : (i += 1) try index.runMaintenance();
+        try std.testing.expect(index.segments.value.file.len > 0);
+    }
+
+    // ...and it still survives, because the manifest carries it too.
+    {
+        const dir = try cwd.openDir(dir_path, .{ .iterate = true });
+        var index = try Self.open(std.testing.allocator, dir, 1, true, null);
+        defer index.deinit();
+        try std.testing.expectError(error.VersionRequired, index.update(
+            &[_]Change{.{ .insert = .{ .id = 7, .hashes = &[_]u32{7} } }},
+            .{},
+        ));
+    }
+}
+
+test "a standalone index mints its own versions and is not poisoned" {
+    const rt = try zio.Runtime.init(std.testing.allocator, .{});
+    defer rt.deinit();
+
+    const cwd = zio.Dir.cwd();
+    const dir_path = "test_index_standalone_versions";
+    cleanupTestDir(cwd, dir_path);
+    try cwd.createDir(dir_path, 0o755);
+    defer cleanupTestDir(cwd, dir_path);
+
+    const dir = try cwd.openDir(dir_path, .{ .iterate = true });
+    var index = try Self.open(std.testing.allocator, dir, 100_000, true, null);
+    defer index.deinit();
+
+    // With no upstream, version and commit id coincide exactly as before the split.
+    var id: u32 = 1;
+    while (id <= 3) : (id += 1) {
+        const v = try index.update(&[_]Change{.{ .insert = .{ .id = id, .hashes = &[_]u32{id} } }}, .{});
+        try std.testing.expectEqual(@as(u64, id), v);
+    }
+    try std.testing.expectEqual(index.commit_id, index.version);
 }

--- a/src/Index.zig
+++ b/src/Index.zig
@@ -31,12 +31,19 @@ const MemoryRef = SharedPtr(MemorySegment);
 const Self = @This();
 
 // Immutable snapshot of the index's segments. Refcounted via SharedPtr(Segments).
-// Both lists are ordered oldest -> newest by version; file segments are older
+// Both lists are ordered oldest -> newest by commit_id; file segments are older
 // than all memory segments.
 pub const Segments = struct {
     allocator: std.mem.Allocator,
     file: []FileRef,
     memory: []MemoryRef,
+    // Internal commit ids: `commit_id` is the newest committed, `file_commit_id` the
+    // newest durable in a file segment (what oplog replay filters on).
+    commit_id: u64 = 0,
+    file_commit_id: u64 = 0,
+    // The same two points expressed as upstream changelog positions: `version`
+    // is what a restarted node resumes from, `file_version` what a snapshot of
+    // this index resumes from (it carries file segments only). See SegmentInfo.
     version: u64 = 0,
     file_version: u64 = 0,
 
@@ -52,9 +59,9 @@ pub const Segments = struct {
         self.* = undefined;
     }
 
-    // The newest segment that mentions `id` wins (segments partition the version
-    // space), giving the doc's current version and whether it's a tombstone.
-    // Returns null if no segment mentions the id at all.
+    // The newest segment that mentions `id` wins (segments partition the commit-id
+    // space), giving the version that doc was last written at and whether it's a
+    // tombstone. Returns null if no segment mentions the id at all.
     pub fn getDocInfo(self: *const Segments, id: u32) ?DocInfo {
         var i = self.memory.len;
         while (i > 0) {
@@ -118,21 +125,21 @@ pub const Segments = struct {
         return md;
     }
 
-    // Newest -> oldest across both lists (globally descending version). Segments
-    // are non-merged per version, so info.version is the doc's version.
-    pub fn hasNewerVersion(self: *const Segments, id: u32, version: u64) bool {
+    // Newest -> oldest across both lists (globally descending commit_id). Segments
+    // are non-merged per commit_id, so info.commit_id is the doc's commit_id.
+    pub fn hasNewerCommit(self: *const Segments, id: u32, commit_id: u64) bool {
         var i = self.memory.len;
         while (i > 0) {
             i -= 1;
             const seg = self.memory[i].value;
-            if (seg.info.version <= version) return false;
+            if (seg.info.commit_id <= commit_id) return false;
             if (id >= seg.min_doc_id and id <= seg.max_doc_id and seg.docs.contains(id)) return true;
         }
         var j = self.file.len;
         while (j > 0) {
             j -= 1;
             const seg = self.file[j].value;
-            if (seg.info.version <= version) return false;
+            if (seg.info.commit_id <= commit_id) return false;
             if (id >= seg.min_doc_id and id <= seg.max_doc_id and seg.docs.contains(id)) return true;
         }
         return false;
@@ -166,6 +173,8 @@ pub const IndexReader = struct {
         try results.finish(segs);
     }
 
+    /// The upstream changelog position this snapshot reflects — what callers, and the
+    /// API, mean by "the index version". Not the internal commit id; see SegmentInfo.
     pub fn version(self: *const IndexReader) u64 {
         return self.snapshot.value.version;
     }
@@ -211,6 +220,13 @@ write_lock: zio.Mutex = .init,
 segments: SharedPtr(Segments),
 
 // Writer-owned bookkeeping (stable under write_lock).
+// Internal: dense commit ids. `file_commit_id` is what oplog replay and truncation
+// key on. See SegmentInfo.
+commit_id: u64 = 0,
+file_commit_id: u64 = 0,
+// External: upstream changelog positions. `version` is the resume point;
+// `file_version` is the watermark a snapshot of this index carries (file segments
+// only), so it is what a peer bootstrapping from here resumes at.
 version: u64 = 0,
 file_version: u64 = 0,
 checkpoint_threshold: usize = 100_000,
@@ -250,6 +266,7 @@ pub fn open(allocator: std.mem.Allocator, dir: zio.Dir, checkpoint_threshold: us
     //    IO-bound (reads the whole file via async IO), so overlapping the loads
     //    keeps many reads in flight through io_uring. Each loader writes its own
     //    slot, so results stay in manifest order.
+    var file_commit_id: u64 = 0;
     var file_version: u64 = 0;
     const infos = try manifest.read(data_dir, allocator);
     defer allocator.free(infos);
@@ -292,24 +309,31 @@ pub fn open(allocator: std.mem.Allocator, dir: zio.Dir, checkpoint_threshold: us
     for (results, refs, infos) |res, ref, info| {
         if (res) |_| {
             file_list.appendAssumeCapacity(ref);
-            file_version = @max(file_version, info.getLastCommitId());
+            file_commit_id = @max(file_commit_id, info.getLastCommitId());
+            file_version = @max(file_version, info.version);
         } else |err| {
             if (err != error.SegmentNotLoaded) fatal = fatal orelse err;
         }
     }
     if (fatal) |err| return err;
 
-    // 2. Open the oplog and replay only the tail (versions > file_version).
-    var ctx = ReplayCtx{ .allocator = allocator, .mem_list = &mem_list, .file_version = file_version };
+    // 2. Open the oplog and replay only the tail (versions > file_commit_id).
+    var ctx = ReplayCtx{ .allocator = allocator, .mem_list = &mem_list, .file_commit_id = file_commit_id };
     var oplog = try Oplog.open(allocator, oplog_dir, sync, &ctx, ReplayCtx.apply);
     errdefer oplog.deinit();
 
+    const commit_id = @max(file_commit_id, oplog.last_commit_id);
+    // The resume point: the newest position durable anywhere, in file segments or in
+    // the replayed WAL tail. Derived independently of the commit id, since the two
+    // no longer move together.
     const version = @max(file_version, oplog.last_version);
 
     const segments = try SharedPtr(Segments).create(allocator, .{
         .allocator = allocator,
         .file = try file_list.toOwnedSlice(allocator),
         .memory = try mem_list.toOwnedSlice(allocator),
+        .commit_id = commit_id,
+        .file_commit_id = file_commit_id,
         .version = version,
         .file_version = file_version,
     });
@@ -321,6 +345,8 @@ pub fn open(allocator: std.mem.Allocator, dir: zio.Dir, checkpoint_threshold: us
         .oplog_dir = oplog_dir,
         .oplog = oplog,
         .segments = segments,
+        .commit_id = commit_id,
+        .file_commit_id = file_commit_id,
         .version = version,
         .file_version = file_version,
         .checkpoint_threshold = checkpoint_threshold,
@@ -353,14 +379,16 @@ fn openOrCreateDir(parent: zio.Dir, name: []const u8) !zio.Dir {
 const ReplayCtx = struct {
     allocator: std.mem.Allocator,
     mem_list: *std.ArrayListUnmanaged(MemoryRef),
-    file_version: u64,
+    file_commit_id: u64,
 
     fn apply(self: *ReplayCtx, txn: Transaction) !void {
-        if (txn.id <= self.file_version) return; // already in a file segment
+        if (txn.id <= self.file_commit_id) return; // already in a file segment
         var ref = try MemoryRef.create(self.allocator, MemorySegment.init(self.allocator, .{}));
         errdefer ref.release(self.allocator, MemorySegment.deinit, .{});
         try ref.value.build(txn.changes);
-        ref.value.info = .{ .version = txn.id, .merges = 0 };
+        // Carry the position too: it is not derivable from the commit id, and losing
+        // it here would silently reset a replayed segment's position to 0.
+        ref.value.info = .{ .commit_id = txn.id, .merges = 0, .version = txn.version };
         try self.mem_list.append(self.allocator, ref);
     }
 };
@@ -388,23 +416,34 @@ pub fn acquireReader(self: *Self) !IndexReader {
 // callers do it BEFORE the durable manifest write — an OOM here commits nothing. On
 // success the snapshot OWNS `file` and `memory`; on failure it consumes neither, so
 // the caller's errdefers release them.
-fn createSnapshot(self: *Self, file: []FileRef, memory: []MemoryRef, version: u64, file_version: u64) !SharedPtr(Segments) {
+const Watermarks = struct {
+    commit_id: u64,
+    file_commit_id: u64,
+    version: u64,
+    file_version: u64,
+};
+
+fn createSnapshot(self: *Self, file: []FileRef, memory: []MemoryRef, w: Watermarks) !SharedPtr(Segments) {
     return SharedPtr(Segments).create(self.allocator, .{
         .allocator = self.allocator,
         .file = file,
         .memory = memory,
-        .version = version,
-        .file_version = file_version,
+        .commit_id = w.commit_id,
+        .file_commit_id = w.file_commit_id,
+        .version = w.version,
+        .file_version = w.file_version,
     });
 }
 
 // Swap a pre-built snapshot into place. Infallible — the allocation already happened
 // in createSnapshot and the lock is uncancelable — so it runs AFTER the durable
 // manifest write with no window where a committed manifest points at state we then
-// fail to install (this mirrors the old version's allocation-free commitUpdate).
+// fail to install (this mirrors the old commit_id's allocation-free commitUpdate).
 // Releases the superseded snapshot, deleting any segment file whose last reference it
-// held, and adopts the snapshot's version bookkeeping. Consumes `snap`.
+// held, and adopts the snapshot's commit_id bookkeeping. Consumes `snap`.
 fn swapSnapshot(self: *Self, snap: SharedPtr(Segments)) void {
+    const commit_id = snap.value.commit_id;
+    const file_commit_id = snap.value.file_commit_id;
     const version = snap.value.version;
     const file_version = snap.value.file_version;
 
@@ -414,6 +453,8 @@ fn swapSnapshot(self: *Self, snap: SharedPtr(Segments)) void {
     self.segments_lock.unlock();
 
     old.release(self.allocator, Segments.deinit, .{});
+    self.commit_id = commit_id;
+    self.file_commit_id = file_commit_id;
     self.version = version;
     self.file_version = file_version;
 }
@@ -460,8 +501,8 @@ pub fn update(self: *Self, changes: []const Change, options: Oplog.WriteOptions)
     errdefer if (!seg_consumed) seg.release(self.allocator, MemorySegment.deinit, .{});
     try seg.value.build(changes);
 
-    const version = try self.oplog.append(changes, options);
-    seg.value.info = .{ .version = version, .merges = 0 };
+    const commit = try self.oplog.append(changes, options);
+    seg.value.info = .{ .commit_id = commit.commit_id, .merges = 0, .version = commit.version };
 
     const cur = self.segments.value;
     const new_file = try cloneRefs(FileSegment, self.allocator, cur.file);
@@ -481,7 +522,12 @@ pub fn update(self: *Self, changes: []const Change, options: Oplog.WriteOptions)
     new_memory[cur.memory.len] = seg;
     seg_consumed = true;
 
-    const snap = try self.createSnapshot(new_file, new_memory, version, self.file_version);
+    const snap = try self.createSnapshot(new_file, new_memory, .{
+        .commit_id = commit.commit_id,
+        .file_commit_id = self.file_commit_id,
+        .version = commit.version,
+        .file_version = self.file_version,
+    });
     arrays_consumed = true;
     self.swapSnapshot(snap);
 
@@ -490,7 +536,9 @@ pub fn update(self: *Self, changes: []const Change, options: Oplog.WriteOptions)
     // Level-triggered, so it's safe even when the coroutine isn't running (tests
     // drive runMaintenance() synchronously instead).
     self.wake.set();
-    return version;
+    // The version, not the commit id: this is what callers see (an _update response, a
+    // read-your-writes wait) and it must be comparable with positions from the feed.
+    return commit.version;
 }
 
 /// Start the background maintenance coroutine. Call once the Index is at its
@@ -645,14 +693,19 @@ fn mergeMemory(self: *Self) !bool {
     const new_file = try cloneRefs(FileSegment, self.allocator, cur.file);
     errdefer if (!arrays_consumed) releaseRefs(FileSegment, self.allocator, new_file);
 
-    var new_snap = try self.createSnapshot(new_file, new_memory, self.version, self.file_version);
+    var new_snap = try self.createSnapshot(new_file, new_memory, .{
+        .commit_id = self.commit_id,
+        .file_commit_id = self.file_commit_id,
+        .version = self.version,
+        .file_version = self.file_version,
+    });
     arrays_consumed = true;
     errdefer if (!committed) new_snap.release(self.allocator, Segments.deinit, .{});
     self.swapSnapshot(new_snap);
     committed = true;
 
     metrics.incMemoryMerges();
-    log.info("merged {} memory segments -> {x}-{x} ({} items)", .{ n, merged.value.info.version, merged.value.info.merges, merged.value.getSize() });
+    log.info("merged {} memory segments -> {x}-{x} ({} items)", .{ n, merged.value.info.commit_id, merged.value.info.merges, merged.value.getSize() });
     return true;
 }
 
@@ -723,7 +776,14 @@ fn checkpoint(self: *Self) !bool {
     // Allocate the snapshot BEFORE the durable manifest write, so the manifest is the
     // last fallible step and the swap after it can't fail (no window where a committed
     // manifest points at state we then fail to install).
-    var new_snap = try self.createSnapshot(new_file, new_memory, self.version, @max(self.file_version, info.getLastCommitId()));
+    var new_snap = try self.createSnapshot(new_file, new_memory, .{
+        .commit_id = self.commit_id,
+        .file_commit_id = @max(self.file_commit_id, info.getLastCommitId()),
+        .version = self.version,
+        // The donor watermark: a snapshot taken now carries this segment, so a
+        // fetcher resumes from the position it covers.
+        .file_version = @max(self.file_version, info.version),
+    });
     arrays_consumed = true;
     errdefer if (!committed) new_snap.release(self.allocator, Segments.deinit, .{});
 
@@ -735,15 +795,15 @@ fn checkpoint(self: *Self) !bool {
     // the segments that arrived during the flush (their real age is ~the flush time).
     self.pending_since = if (kept.len == 0) null else zio.Timestamp.now(.monotonic);
 
-    // Transactions up to file_version are now durable in file segments; drop the
+    // Transactions up to file_commit_id are now durable in file segments; drop the
     // oplog files entirely below it. (After the manifest commit, so a crash in
     // between just leaves redundant oplog entries that replay skips.)
-    self.oplog.truncate(self.file_version) catch |err| {
+    self.oplog.truncate(self.file_commit_id) catch |err| {
         log.warn("oplog truncate failed: {}", .{err});
     };
 
     metrics.incCheckpoints();
-    log.info("checkpointed to file segment {x}-{x} ({} items)", .{ info.version, info.merges, fseg.value.num_items });
+    log.info("checkpointed to file segment {x}-{x} ({} items)", .{ info.commit_id, info.merges, fseg.value.num_items });
     return true;
 }
 
@@ -817,7 +877,12 @@ fn mergeFiles(self: *Self) !bool {
 
     // Allocate the snapshot BEFORE the durable manifest write (see checkpoint), so the
     // swap after the manifest is infallible.
-    var new_snap = try self.createSnapshot(new_file, new_memory, self.version, self.file_version);
+    var new_snap = try self.createSnapshot(new_file, new_memory, .{
+        .commit_id = self.commit_id,
+        .file_commit_id = self.file_commit_id,
+        .version = self.version,
+        .file_version = self.file_version,
+    });
     arrays_consumed = true;
     errdefer if (!committed) new_snap.release(self.allocator, Segments.deinit, .{});
 
@@ -832,12 +897,12 @@ fn mergeFiles(self: *Self) !bool {
     for (cur.file[lo..hi]) |s| s.value.delete_on_destroy = true;
 
     metrics.incFileMerges();
-    log.info("merged {} file segments -> {x}-{x} ({} items)", .{ n, info.version, info.merges, fseg.value.num_items });
+    log.info("merged {} file segments -> {x}-{x} ({} items)", .{ n, info.commit_id, info.merges, fseg.value.num_items });
     return true;
 }
 
 // Merge `sources` into a new on-disk file segment and load it back. `collection`
-// provides hasNewerVersion (the current snapshot). On error the written file is
+// provides hasNewerCommit (the current snapshot). On error the written file is
 // removed. Caller owns the returned ref.
 fn mergeToFileSegment(self: *Self, comptime Segment: type, sources: []SharedPtr(Segment), collection: anytype) !FileRef {
     var merger = try SegmentMerger(Segment).init(self.allocator, sources.len);
@@ -1007,13 +1072,13 @@ test "snapshot archive round-trips manifest + file segments" {
     try std.testing.expectEqual(@as(u64, 7), parsed.generation);
     try std.testing.expectEqual(segs.file.len, parsed.entries.len);
     for (segs.file, 0..) |s, i| {
-        try std.testing.expectEqual(s.value.info.version, parsed.entries[i].info.version);
+        try std.testing.expectEqual(s.value.info.commit_id, parsed.entries[i].info.commit_id);
         try std.testing.expectEqual(s.value.info.merges, parsed.entries[i].info.merges);
         try std.testing.expectEqualSlices(u8, s.value.data, parsed.entries[i].data);
     }
 }
 
-test "snapshot restores into a fresh dir and opens at the same version" {
+test "snapshot restores into a fresh dir and opens at the same commit_id" {
     const snapshot = @import("snapshot.zig");
     const rt = try zio.Runtime.init(std.testing.allocator, .{});
     defer rt.deinit();
@@ -1041,7 +1106,7 @@ test "snapshot restores into a fresh dir and opens at the same version" {
     try src.runMaintenance();
 
     var reader = try src.acquireReader();
-    const src_version = reader.snapshot.value.version;
+    const src_version = reader.snapshot.value.commit_id;
     var buf: std.Io.Writer.Allocating = .init(std.testing.allocator);
     defer buf.deinit();
     try snapshot.writeSnapshot(&buf.writer, a, reader.snapshot.value, 7);
@@ -1058,14 +1123,14 @@ test "snapshot restores into a fresh dir and opens at the same version" {
     var rw = std.Io.Reader.fixed(buf.written());
     try std.testing.expectError(error.SnapshotGenerationMismatch, snapshot.restoreInto(dst_data, &rw, a, 8));
 
-    // Restore the right generation, then open: same version, data searchable.
+    // Restore the right generation, then open: same commit_id, data searchable.
     var rr = std.Io.Reader.fixed(buf.written());
     try snapshot.restoreInto(dst_data, &rr, a, 7);
     dst_data.close();
 
     var dst = try Self.open(std.testing.allocator, dst_dir, 100_000, true, null);
     defer dst.deinit();
-    try std.testing.expectEqual(src_version, dst.version);
+    try std.testing.expectEqual(src_version, dst.commit_id);
 
     var results = SearchResults.init(a, .{});
     defer results.deinit();
@@ -1158,7 +1223,7 @@ test "checkpoint and reload" {
 
         try std.testing.expectEqual(@as(usize, 1), index.segments.value.file.len);
         try std.testing.expectEqual(@as(usize, 0), index.segments.value.memory.len);
-        try std.testing.expectEqual(@as(u64, 2), index.version);
+        try std.testing.expectEqual(@as(u64, 2), index.commit_id);
 
         var results = SearchResults.init(std.testing.allocator, .{ .max_results = 10, .min_score = 1 });
         defer results.deinit();
@@ -1337,7 +1402,7 @@ test "oplog truncation after checkpoint" {
     }
 }
 
-test "getDocInfo reports version and tombstones, across a checkpoint" {
+test "getDocInfo reports commit_id and tombstones, across a checkpoint" {
     const rt = try zio.Runtime.init(std.testing.allocator, .{});
     defer rt.deinit();
 
@@ -1445,7 +1510,7 @@ test "oplog recovers the valid prefix from a corrupt tail" {
         while (id <= 5) : (id += 1) {
             _ = try index.update(&[_]Change{.{ .insert = .{ .id = id, .hashes = &[_]u32{ 100, id } } }}, .{});
         }
-        try std.testing.expectEqual(@as(u64, 5), index.version);
+        try std.testing.expectEqual(@as(u64, 5), index.commit_id);
     }
 
     // Append a full but CRC-invalid framed record to the tail (a crash could leave
@@ -1453,7 +1518,7 @@ test "oplog recovers the valid prefix from a corrupt tail" {
     {
         var oplog_dir = try cwd.openDir(dir_path ++ "/oplog", .{ .iterate = true });
         defer oplog_dir.close();
-        const name = "0000000000000001.xlog"; // first record's version = 1
+        const name = "0000000000000001.xlog"; // first record's commit_id = 1
         const st = try oplog_dir.statPath(name);
         const file = try oplog_dir.openFile(name, .{ .mode = .read_write });
         defer file.close();
@@ -1472,7 +1537,7 @@ test "oplog recovers the valid prefix from a corrupt tail" {
         const dir = try cwd.openDir(dir_path, .{ .iterate = true });
         var index = try Self.open(std.testing.allocator, dir, 100_000, true, null);
         defer index.deinit();
-        try std.testing.expectEqual(@as(u64, 5), index.version);
+        try std.testing.expectEqual(@as(u64, 5), index.commit_id);
 
         var results = SearchResults.init(std.testing.allocator, .{ .max_results = 100, .min_score = 1 });
         defer results.deinit();
@@ -1481,5 +1546,112 @@ test "oplog recovers the valid prefix from a corrupt tail" {
         var h = [_]u32{100};
         try reader.search(&h, &results);
         try std.testing.expectEqual(@as(usize, 5), results.getResults().len);
+    }
+}
+
+test "coalesced batches keep commit ids dense while positions jump" {
+    const rt = try zio.Runtime.init(std.testing.allocator, .{});
+    defer rt.deinit();
+
+    const cwd = zio.Dir.cwd();
+    const dir_path = "test_index_coalesced";
+    cleanupTestDir(cwd, dir_path);
+    try cwd.createDir(dir_path, 0o755);
+    defer cleanupTestDir(cwd, dir_path);
+
+    const dir = try cwd.openDir(dir_path, .{ .iterate = true });
+    var index = try Self.open(std.testing.allocator, dir, 100_000, true, null); // no checkpoint
+    defer index.deinit();
+
+    // A consumer coalesces a run of feed entries into one apply, so positions jump by
+    // the batch size. Before commit ids and positions were separated this fed a
+    // non-dense value into SegmentInfo.commit_id and merging tripped its adjacency
+    // assertion (`commit_id + merges + 1 == other.commit_id`).
+    var pos: u64 = 0;
+    var id: u32 = 1;
+    while (id <= 50) : (id += 1) {
+        pos += 10;
+        _ = try index.update(&[_]Change{.{ .insert = .{ .id = id, .hashes = &[_]u32{id} } }}, .{ .version = pos });
+        try index.runMaintenance(); // merges memory segments
+    }
+
+    try std.testing.expect(index.segments.value.memory.len < 50); // merging happened
+    try std.testing.expectEqual(@as(u64, 500), index.version); // external position
+    try std.testing.expectEqual(@as(u64, 50), index.commit_id); // dense internal ids
+
+    // The merged segments still tile the commit-id sequence without gaps.
+    var expected: u64 = 1;
+    for (index.segments.value.memory) |seg| {
+        try std.testing.expectEqual(expected, seg.value.info.commit_id);
+        expected = seg.value.info.getLastCommitId() + 1;
+    }
+    try std.testing.expectEqual(@as(u64, 51), expected);
+
+    // And every doc is still searchable.
+    var results = SearchResults.init(std.testing.allocator, .{ .max_results = 100, .min_score = 1 });
+    defer results.deinit();
+    var reader = try index.acquireReader();
+    defer reader.deinit();
+    var h = [_]u32{25};
+    try reader.search(&h, &results);
+    try std.testing.expectEqual(@as(usize, 1), results.getResults().len);
+}
+
+test "version survives checkpoint and restart, and drives the donor watermark" {
+    const rt = try zio.Runtime.init(std.testing.allocator, .{});
+    defer rt.deinit();
+
+    const cwd = zio.Dir.cwd();
+    const dir_path = "test_index_logpos_restart";
+    cleanupTestDir(cwd, dir_path);
+    try cwd.createDir(dir_path, 0o755);
+    defer cleanupTestDir(cwd, dir_path);
+
+    var checkpointed_at: u64 = 0;
+    {
+        const dir = try cwd.openDir(dir_path, .{ .iterate = true });
+        var index = try Self.open(std.testing.allocator, dir, 10, true, null);
+        defer index.deinit();
+
+        // Write until something has been checkpointed into a file segment.
+        var pos: u64 = 0;
+        var id: u32 = 1;
+        while (id <= 40) : (id += 1) {
+            pos += 7; // positions jump; commit ids stay dense
+            _ = try index.update(&[_]Change{.{ .insert = .{ .id = id, .hashes = &[_]u32{ 100, id } } }}, .{ .version = pos });
+            try index.runMaintenance();
+        }
+        try std.testing.expect(index.segments.value.file.len > 0);
+
+        // The donor watermark is a real position, and never ahead of the resume point.
+        checkpointed_at = index.file_version;
+        try std.testing.expect(checkpointed_at > 0);
+        try std.testing.expect(checkpointed_at <= index.version);
+        try std.testing.expectEqual(@as(u64, 280), index.version);
+        try std.testing.expectEqual(@as(u64, 40), index.commit_id); // dense commit ids
+
+        // A write that stays in memory moves the resume point but NOT the watermark a
+        // snapshot would hand a fetcher — a snapshot carries file segments only.
+        _ = try index.update(&[_]Change{.{ .insert = .{ .id = 99, .hashes = &[_]u32{999} } }}, .{ .version = 5000 });
+        try std.testing.expectEqual(@as(u64, 5000), index.version);
+        try std.testing.expectEqual(checkpointed_at, index.file_version);
+    }
+
+    // Reopen: the position comes back from the manifest plus the replayed WAL tail,
+    // derived independently of the commit ids.
+    {
+        const dir = try cwd.openDir(dir_path, .{ .iterate = true });
+        var index = try Self.open(std.testing.allocator, dir, 10, true, null);
+        defer index.deinit();
+        try std.testing.expectEqual(@as(u64, 5000), index.version);
+        try std.testing.expectEqual(@as(u64, 41), index.commit_id);
+        try std.testing.expectEqual(checkpointed_at, index.file_version);
+
+        // Doc 99 was memory-only, so it comes back through oplog replay. Its position
+        // must survive that: replay rebuilds the segment info by hand, and dropping
+        // the position there silently reports every replayed doc as position 0.
+        var reader = try index.acquireReader();
+        defer reader.deinit();
+        try std.testing.expectEqual(@as(u64, 5000), reader.getDocInfo(99).?.version);
     }
 }

--- a/src/Index.zig
+++ b/src/Index.zig
@@ -71,7 +71,7 @@ pub const Segments = struct {
             i -= 1;
             const seg = self.memory[i].value;
             if (id >= seg.min_doc_id and id <= seg.max_doc_id) {
-                if (seg.docs.get(id)) |alive| return .{ .version = seg.info.version, .deleted = !alive };
+                if (seg.docs.get(id)) |alive| return .{ .version = seg.info.effectiveVersion(), .deleted = !alive };
             }
         }
         var j = self.file.len;
@@ -79,7 +79,7 @@ pub const Segments = struct {
             j -= 1;
             const seg = self.file[j].value;
             if (id >= seg.min_doc_id and id <= seg.max_doc_id) {
-                if (seg.docs.get(id)) |alive| return .{ .version = seg.info.version, .deleted = !alive };
+                if (seg.docs.get(id)) |alive| return .{ .version = seg.info.effectiveVersion(), .deleted = !alive };
             }
         }
         return null;
@@ -227,6 +227,9 @@ segments: SharedPtr(Segments),
 // key on. See SegmentInfo.
 commit_id: u64 = 0,
 file_commit_id: u64 = 0,
+// Derived at open from the segments and the replayed WAL, then kept up to date by
+// update(): true once anything in this index carries an upstream position.
+external_versions: bool = false,
 // External: upstream changelog positions. `version` is the resume point;
 // `file_version` is the watermark a snapshot of this index carries (file segments
 // only), so it is what a peer bootstrapping from here resumes at.
@@ -271,8 +274,11 @@ pub fn open(allocator: std.mem.Allocator, dir: zio.Dir, checkpoint_threshold: us
     //    slot, so results stay in manifest order.
     var file_commit_id: u64 = 0;
     var file_version: u64 = 0;
-    const loaded = try manifest.read(data_dir, allocator);
-    const infos = loaded.segments;
+    // Upstream-fed is derived, not stored: any segment carrying a position marks it.
+    // The manifest and the WAL cover each other — a checkpoint truncates the WAL only
+    // once its transactions are durable in a segment, which then carries the position.
+    var external_versions: bool = false;
+    const infos = try manifest.read(data_dir, allocator);
     defer allocator.free(infos);
 
     const refs = try allocator.alloc(FileRef, infos.len);
@@ -314,7 +320,8 @@ pub fn open(allocator: std.mem.Allocator, dir: zio.Dir, checkpoint_threshold: us
         if (res) |_| {
             file_list.appendAssumeCapacity(ref);
             file_commit_id = @max(file_commit_id, info.getLastCommitId());
-            file_version = @max(file_version, info.version);
+            file_version = @max(file_version, info.effectiveVersion());
+            if (info.version != null) external_versions = true;
         } else |err| {
             if (err != error.SegmentNotLoaded) fatal = fatal orelse err;
         }
@@ -325,17 +332,21 @@ pub fn open(allocator: std.mem.Allocator, dir: zio.Dir, checkpoint_threshold: us
     var ctx = ReplayCtx{ .allocator = allocator, .mem_list = &mem_list, .file_commit_id = file_commit_id };
     var oplog = try Oplog.open(allocator, oplog_dir, sync, &ctx, ReplayCtx.apply);
     errdefer oplog.deinit();
-    // Replay only sees transactions still in the WAL, and a checkpoint truncates it —
-    // so the sticky marker has to come back from the manifest too, or an index whose
-    // data is fully checkpointed would forget it had an upstream and start minting
-    // local versions on top of upstream ones.
-    if (loaded.external_versions) oplog.external_versions = true;
+    if (oplog.saw_external) external_versions = true;
 
     const commit_id = @max(file_commit_id, oplog.last_commit_id);
     // The resume point: the newest position durable anywhere, in file segments or in
     // the replayed WAL tail. Derived independently of the commit id, since the two
     // no longer move together.
     const version = @max(file_version, oplog.last_version);
+
+    // The WAL can hold less than the index does: a bootstrap deletes it outright and
+    // restores segments carrying the donor's commit ids. Seed it from the recovered
+    // maxima, or the next append would mint commit id 1 on top of existing segments —
+    // breaking the dense tiling SegmentInfo.merge asserts on, and colliding with
+    // segment file names, which are built from the commit id.
+    oplog.last_commit_id = commit_id;
+    oplog.last_version = version;
 
     const segments = try SharedPtr(Segments).create(allocator, .{
         .allocator = allocator,
@@ -345,7 +356,7 @@ pub fn open(allocator: std.mem.Allocator, dir: zio.Dir, checkpoint_threshold: us
         .file_commit_id = file_commit_id,
         .version = version,
         .file_version = file_version,
-        .external_versions = oplog.external_versions,
+        .external_versions = external_versions,
     });
 
     return .{
@@ -359,6 +370,7 @@ pub fn open(allocator: std.mem.Allocator, dir: zio.Dir, checkpoint_threshold: us
         .file_commit_id = file_commit_id,
         .version = version,
         .file_version = file_version,
+        .external_versions = external_versions,
         .checkpoint_threshold = checkpoint_threshold,
     };
 }
@@ -442,7 +454,7 @@ fn createSnapshot(self: *Self, file: []FileRef, memory: []MemoryRef, w: Watermar
         .file_commit_id = w.file_commit_id,
         .version = w.version,
         .file_version = w.file_version,
-        .external_versions = self.oplog.external_versions,
+        .external_versions = self.external_versions,
     });
 }
 
@@ -507,13 +519,22 @@ pub fn update(self: *Self, changes: []const Change, options: Oplog.WriteOptions)
     zio.beginShield();
     defer zio.endShield();
 
+    // Once anything in this index carries an upstream position, every later commit
+    // needs one. Minting a local version on top of upstream ones would invent a
+    // position the upstream never issued — and this node advertises that number as a
+    // watermark, so a peer bootstrapping from it would resume the feed at a position
+    // that does not exist and skip whatever really sits there.
+    if (self.external_versions and options.version == null) return error.VersionRequired;
+
     var seg = try MemoryRef.create(self.allocator, MemorySegment.init(self.allocator, .{}));
     var seg_consumed = false;
     errdefer if (!seg_consumed) seg.release(self.allocator, MemorySegment.deinit, .{});
     try seg.value.build(changes);
 
     const commit = try self.oplog.append(changes, options);
-    seg.value.info = .{ .commit_id = commit.commit_id, .merges = 0, .version = commit.version };
+    // `options.version`, not the resolved one: a local commit must leave this null, or
+    // the segment would look upstream-fed and poison an index that never had a feed.
+    seg.value.info = .{ .commit_id = commit.commit_id, .merges = 0, .version = options.version };
 
     const cur = self.segments.value;
     const new_file = try cloneRefs(FileSegment, self.allocator, cur.file);
@@ -546,6 +567,7 @@ pub fn update(self: *Self, changes: []const Change, options: Oplog.WriteOptions)
     // then file merge). Signal the coroutine; it decides what's actually needed.
     // Level-triggered, so it's safe even when the coroutine isn't running (tests
     // drive runMaintenance() synchronously instead).
+    if (options.version != null) self.external_versions = true;
     self.wake.set();
     // The version, not the commit id: this is what callers see (an _update response, a
     // read-your-writes wait) and it must be comparable with positions from the feed.
@@ -793,7 +815,7 @@ fn checkpoint(self: *Self) !bool {
         .version = self.version,
         // The donor watermark: a snapshot taken now carries this segment, so a
         // fetcher resumes from the position it covers.
-        .file_version = @max(self.file_version, info.version),
+        .file_version = @max(self.file_version, info.effectiveVersion()),
     });
     arrays_consumed = true;
     errdefer if (!committed) new_snap.release(self.allocator, Segments.deinit, .{});
@@ -943,11 +965,7 @@ fn writeManifestFor(self: *Self, file: []const FileRef) !void {
     const infos = try self.allocator.alloc(SegmentInfo, file.len);
     defer self.allocator.free(infos);
     for (file, 0..) |seg, i| infos[i] = seg.value.info;
-    try manifest.write(self.data_dir, self.allocator, .{
-        .segments = infos,
-        // Carried across checkpoints: the oplog that recorded it is truncated.
-        .external_versions = self.oplog.external_versions,
-    });
+    try manifest.write(self.data_dir, self.allocator, infos);
 }
 
 fn cleanupTestDir(cwd: zio.Dir, path: []const u8) void {
@@ -1760,4 +1778,54 @@ test "a standalone index mints its own versions and is not poisoned" {
         try std.testing.expectEqual(@as(u64, id), v);
     }
     try std.testing.expectEqual(index.commit_id, index.version);
+}
+
+test "a restored index continues commit ids instead of restarting them" {
+    const rt = try zio.Runtime.init(std.testing.allocator, .{});
+    defer rt.deinit();
+
+    const cwd = zio.Dir.cwd();
+    const dir_path = "test_index_restored_commit_ids";
+    cleanupTestDir(cwd, dir_path);
+    try cwd.createDir(dir_path, 0o755);
+    defer cleanupTestDir(cwd, dir_path);
+
+    var restored_commit_id: u64 = 0;
+    {
+        const dir = try cwd.openDir(dir_path, .{ .iterate = true });
+        var index = try Self.open(std.testing.allocator, dir, 1, true, null);
+        defer index.deinit();
+        var id: u32 = 1;
+        while (id <= 20) : (id += 1) {
+            _ = try index.update(&[_]Change{.{ .insert = .{ .id = id, .hashes = &[_]u32{id} } }}, .{});
+            try index.runMaintenance();
+        }
+        try std.testing.expect(index.segments.value.file.len > 0);
+        restored_commit_id = index.commit_id;
+    }
+
+    // A peer bootstrap swaps in restored segments and deletes the WAL outright
+    // (MultiIndex.swapAndReopen), so the oplog comes back empty while the segments
+    // carry commit ids from the donor.
+    {
+        var dir = try cwd.openDir(dir_path, .{ .iterate = true });
+        defer dir.close();
+        @import("common.zig").deleteDirTree(std.testing.allocator, dir, "oplog") catch {};
+    }
+
+    {
+        const dir = try cwd.openDir(dir_path, .{ .iterate = true });
+        var index = try Self.open(std.testing.allocator, dir, 100_000, true, null);
+        defer index.deinit();
+        try std.testing.expectEqual(restored_commit_id, index.commit_id);
+
+        // The next commit must continue the sequence. Restarting at 1 would collide
+        // with the restored segments' ids and break their dense tiling.
+        _ = try index.update(&[_]Change{.{ .insert = .{ .id = 99, .hashes = &[_]u32{99} } }}, .{});
+        try std.testing.expectEqual(restored_commit_id + 1, index.commit_id);
+
+        // And merging still holds, which is what the tiling exists for.
+        var i: usize = 0;
+        while (i < 5) : (i += 1) try index.runMaintenance();
+    }
 }

--- a/src/Index.zig
+++ b/src/Index.zig
@@ -332,7 +332,7 @@ pub fn open(allocator: std.mem.Allocator, dir: zio.Dir, checkpoint_threshold: us
     var ctx = ReplayCtx{ .allocator = allocator, .mem_list = &mem_list, .file_commit_id = file_commit_id };
     var oplog = try Oplog.open(allocator, oplog_dir, sync, &ctx, ReplayCtx.apply);
     errdefer oplog.deinit();
-    if (oplog.saw_external) external_versions = true;
+    if (ctx.external_versions) external_versions = true;
 
     const commit_id = @max(file_commit_id, oplog.last_commit_id);
     // The resume point: the newest position durable anywhere, in file segments or in
@@ -402,14 +402,16 @@ const ReplayCtx = struct {
     allocator: std.mem.Allocator,
     mem_list: *std.ArrayListUnmanaged(MemoryRef),
     file_commit_id: u64,
+    external_versions: bool = false,
 
     fn apply(self: *ReplayCtx, txn: Transaction) !void {
+        // Before the filter below: a checkpointed transaction still tells us this
+        // index has an upstream, even though its data already sits in a segment.
+        if (txn.version != null) self.external_versions = true;
         if (txn.id <= self.file_commit_id) return; // already in a file segment
         var ref = try MemoryRef.create(self.allocator, MemorySegment.init(self.allocator, .{}));
         errdefer ref.release(self.allocator, MemorySegment.deinit, .{});
         try ref.value.build(txn.changes);
-        // Carry the position too: it is not derivable from the commit id, and losing
-        // it here would silently reset a replayed segment's position to 0.
         ref.value.info = .{ .commit_id = txn.id, .merges = 0, .version = txn.version };
         try self.mem_list.append(self.allocator, ref);
     }
@@ -1435,7 +1437,7 @@ test "oplog truncation after checkpoint" {
     }
 }
 
-test "getDocInfo reports commit_id and tombstones, across a checkpoint" {
+test "getDocInfo reports version and tombstones, across a checkpoint" {
     const rt = try zio.Runtime.init(std.testing.allocator, .{});
     defer rt.deinit();
 

--- a/src/MemorySegment.zig
+++ b/src/MemorySegment.zig
@@ -47,7 +47,7 @@ pub fn search(self: Self, sorted_hashes: []const u32, results: *SearchResults) !
         try zio.maybeYield();
         const matches = std.sort.equalRange(Item, items, Item{ .hash = hash, .id = 0 }, Item.orderByHash);
         for (matches[0]..matches[1]) |i| {
-            try results.incr(items[i].id, self.info.version);
+            try results.incr(items[i].id, self.info.commit_id);
         }
         items = items[matches[1]..];
     }

--- a/src/MultiIndex.zig
+++ b/src/MultiIndex.zig
@@ -375,10 +375,13 @@ fn foldMetadata(arena: std.mem.Allocator, changes: []const Change, metadata: ?Me
 }
 
 /// Apply changes at an externally-assigned version (the replicated consumer's
-/// apply path; version = the lineage's per-feed seq). `generation` guards against
-/// applying to a lineage that was rebuilt underneath the consumer. The external log
-/// owns ordering and durability, so this just stamps the version onto the local
-/// oplog + segments.
+/// apply path; `version` = the lineage's per-feed seq). `generation` guards
+/// against applying to a lineage that was rebuilt underneath the consumer. The
+/// external log owns ordering and durability, so this just records the position
+/// against a locally-minted commit.
+///
+/// Note a batch may coalesce many feed entries into one commit, which is exactly why
+/// the position cannot double as the commit id.
 pub fn applyLog(self: *Self, name: []const u8, generation: u64, changes: []const Change, version: u64) !void {
     const index = try self.getIndexForGeneration(name, generation);
     defer self.releaseIndex(index);

--- a/src/Oplog.zig
+++ b/src/Oplog.zig
@@ -1,8 +1,10 @@
 // Per-index write-ahead log. Transactions are appended to rotating ".xlog" files
-// named by their first commit id. The commit id is the index version
-// (log-position-as-version). On startup the files are replayed in order; after a
-// checkpoint, truncate() deletes files whose transactions are all durable in file
-// segments.
+// named by their first commit id. Commit ids are minted here, one per transaction,
+// and are dense — segments tile them, which SegmentInfo.merge asserts on. Each
+// transaction also carries the upstream changelog `version` it corresponds to; the
+// two are NOT the same number (see SegmentInfo). On startup the files are replayed in
+// order; after a checkpoint, truncate() deletes files whose transactions are all
+// durable in file segments.
 //
 // Each record is framed [u32 payload_len][u32 crc32(payload)][payload] so replay
 // can detect a torn/corrupt tail (a crash mid-append) and recover the valid
@@ -35,11 +37,13 @@ const record_header_size = 8; // u32 payload_len + u32 crc32
 const max_record_size = 64 * 1024 * 1024; // sanity bound for a framed payload
 
 pub const WriteOptions = struct {
-    // Optimistic concurrency: fail with error.VersionMismatch if the current
-    // version doesn't match.
+    // Optimistic concurrency: fail with error.VersionMismatch if the index is not at
+    // this version. Only reachable in standalone mode (a replicated apply never sets
+    // it), where a commit's version is its own commit id.
     expected_version: ?u64 = null,
-    // Apply at this externally-assigned version (replicated apply from an upstream
-    // log); null mints the next local version.
+    // The upstream changelog position this commit corresponds to (replicated apply).
+    // null means there is no upstream — standalone writes take the commit id itself,
+    // so the two coincide exactly as they did before they were separated.
     version: ?u64 = null,
 };
 
@@ -53,6 +57,7 @@ current_file: ?zio.File = null,
 current_start: u64 = 0,
 current_size: usize = 0,
 write_offset: u64 = 0,
+last_commit_id: u64 = 0,
 last_version: u64 = 0,
 max_file_size: usize = default_max_file_size,
 
@@ -139,7 +144,8 @@ fn replay(self: *Self, ctx: anytype, handler: anytype) !void {
             _ = arena.reset(.retain_capacity);
             switch (try readRecord(&reader.interface, arena.allocator())) {
                 .record => |txn| {
-                    self.last_version = @max(self.last_version, txn.id);
+                    self.last_commit_id = @max(self.last_commit_id, txn.id);
+                    self.last_version = @max(self.last_version, txn.version);
                     try handler(ctx, txn);
                     count += 1;
                 },
@@ -148,20 +154,20 @@ fn replay(self: *Self, ctx: anytype, handler: anytype) !void {
                     // A torn record can only be the tail (a crash mid-append writes
                     // the last record; nothing follows it). Recover the prefix and
                     // stop — a later append or the PG poller refills from here.
-                    log.warn("oplog: torn record in {s}, stopping replay at version {d}", .{ name, self.last_version });
+                    log.warn("oplog: torn record in {s}, stopping replay at commit_id {d}", .{ name, self.last_commit_id });
                     break :files;
                 },
             }
         }
     }
     if (count > 0) {
-        log.info("replayed {d} transactions, version {d}", .{ count, self.last_version });
+        log.info("replayed {d} transactions, commit_id {d}", .{ count, self.last_commit_id });
     }
 }
 
-// Current append file, rotating to a new one (named by `version`) when full or
+// Current append file, rotating to a new one (named by `commit_id`) when full or
 // on the first append after open.
-fn getFile(self: *Self, version: u64) !zio.File {
+fn getFile(self: *Self, commit_id: u64) !zio.File {
     if (self.current_file) |file| {
         if (self.current_size < self.max_file_size) return file;
         file.close();
@@ -169,32 +175,43 @@ fn getFile(self: *Self, version: u64) !zio.File {
     }
 
     var name_buf: [file_name_len]u8 = undefined;
-    const name = buildName(&name_buf, version);
+    const name = buildName(&name_buf, commit_id);
     const file = try self.dir.createFile(name, .{ .truncate = true });
     errdefer file.close();
-    try self.files.append(self.allocator, version);
+    try self.files.append(self.allocator, commit_id);
 
     self.current_file = file;
-    self.current_start = version;
+    self.current_start = commit_id;
     self.current_size = 0;
     self.write_offset = 0;
     return file;
 }
 
-/// Append a transaction (framed, fsync if `sync`). Returns the version: the one
-/// in `options.version` (replicated apply) or the next local one. With
-/// `options.expected_version` set and mismatched, fails with error.VersionMismatch
-/// and writes nothing.
-pub fn append(self: *Self, changes: []const Change, options: WriteOptions) !u64 {
+/// The identity of a committed transaction: its dense internal commit id and the
+/// upstream changelog position it covers.
+pub const Commit = struct {
+    commit_id: u64,
+    version: u64,
+};
+
+/// Append a transaction (framed, fsync if `sync`). Returns the minted commit id and
+/// the version it carries. With `options.expected_version` set and mismatched,
+/// fails with error.VersionMismatch and writes nothing.
+pub fn append(self: *Self, changes: []const Change, options: WriteOptions) !Commit {
     if (options.expected_version) |expected| {
         if (self.last_version != expected) return error.VersionMismatch;
     }
-    const version = options.version orelse (self.last_version + 1);
+    // Commit ids are always minted locally and densely. They used to be overridden
+    // with the upstream position, which broke the density SegmentInfo.merge asserts
+    // on as soon as a consumer coalesced a batch (one commit spanning many positions).
+    const commit_id = self.last_commit_id + 1;
+    const version = options.version orelse commit_id;
 
     var w = std.Io.Writer.Allocating.init(self.allocator);
     defer w.deinit();
     try msgpack.encode(Transaction{
-        .id = version,
+        .id = commit_id,
+        .version = version,
         .changes = changes,
     }, &w.writer);
     const payload = w.written();
@@ -204,13 +221,14 @@ pub fn append(self: *Self, changes: []const Change, options: WriteOptions) !u64 
     std.mem.writeInt(u32, header[4..8], std.hash.crc.Crc32.hash(payload), .little);
 
     // getFile may rotate (resetting write_offset), so call it before writing.
-    const file = try self.getFile(version);
+    const file = try self.getFile(commit_id);
     try self.writeAll(file, &header);
     try self.writeAll(file, payload);
     if (self.sync) try file.sync(.{});
 
+    self.last_commit_id = commit_id;
     self.last_version = version;
-    return version;
+    return .{ .commit_id = commit_id, .version = version };
 }
 
 fn writeAll(self: *Self, file: zio.File, bytes: []const u8) !void {
@@ -226,12 +244,12 @@ fn cmpVersion(v: u64, item: u64) std.math.Order {
     return std.math.order(v, item);
 }
 
-/// Delete oplog files whose transactions are all below `version` (now durable in
-/// file segments). Keeps the file that spans `version` and all newer files.
-pub fn truncate(self: *Self, version: u64) !void {
-    // First file whose start >= version; keep the one before it (it may span
-    // `version`), so files strictly before that are safe to delete.
-    var keep_from = std.sort.lowerBound(u64, self.files.items, version, cmpVersion);
+/// Delete oplog files whose transactions are all below `commit_id` (now durable in
+/// file segments). Keeps the file that spans `commit_id` and all newer files.
+pub fn truncate(self: *Self, commit_id: u64) !void {
+    // First file whose start >= commit_id; keep the one before it (it may span
+    // `commit_id`), so files strictly before that are safe to delete.
+    var keep_from = std.sort.lowerBound(u64, self.files.items, commit_id, cmpVersion);
     if (keep_from > 0) keep_from -= 1;
 
     var deleted: usize = 0;
@@ -248,6 +266,6 @@ pub fn truncate(self: *Self, version: u64) !void {
         const remaining = self.files.items.len - deleted;
         std.mem.copyForwards(u64, self.files.items[0..remaining], self.files.items[deleted..]);
         self.files.shrinkRetainingCapacity(remaining);
-        log.info("truncated {d} oplog files below version {d}", .{ deleted, version });
+        log.info("truncated {d} oplog files below commit_id {d}", .{ deleted, commit_id });
     }
 }

--- a/src/Oplog.zig
+++ b/src/Oplog.zig
@@ -59,9 +59,10 @@ current_size: usize = 0,
 write_offset: u64 = 0,
 last_commit_id: u64 = 0,
 last_version: u64 = 0,
-// Sticky: set once a commit carries an upstream position, restored on replay and
-// from the manifest. Once set, a positionless write is refused. See append().
-external_versions: bool = false,
+// Whether any replayed transaction carried an upstream position. The Index combines
+// this with the manifest to decide whether the index is upstream-fed; the oplog itself
+// holds no policy.
+saw_external: bool = false,
 max_file_size: usize = default_max_file_size,
 
 fn buildName(buf: []u8, start: u64) []u8 {
@@ -148,8 +149,10 @@ fn replay(self: *Self, ctx: anytype, handler: anytype) !void {
             switch (try readRecord(&reader.interface, arena.allocator())) {
                 .record => |txn| {
                     self.last_commit_id = @max(self.last_commit_id, txn.id);
-                    self.last_version = @max(self.last_version, txn.version);
-                    if (txn.external) self.external_versions = true;
+                    // A locally-minted commit has no stored position: its version is
+                    // its commit id, which is the standalone identity.
+                    self.last_version = @max(self.last_version, txn.version orelse txn.id);
+                    if (txn.version != null) self.saw_external = true;
                     try handler(ctx, txn);
                     count += 1;
                 },
@@ -205,13 +208,6 @@ pub fn append(self: *Self, changes: []const Change, options: WriteOptions) !Comm
     if (options.expected_version) |expected| {
         if (self.last_version != expected) return error.VersionMismatch;
     }
-    // Once an index has taken a position from an upstream feed, every later commit
-    // needs one too. Minting a local version on top of upstream ones would invent a
-    // position the upstream never issued — and this node advertises that number as a
-    // watermark, so a peer bootstrapping from it would resume the feed at a position
-    // that does not exist and skip whatever really sits there.
-    if (self.external_versions and options.version == null) return error.VersionRequired;
-
     // Commit ids are always minted locally and densely. They used to be overridden
     // with the upstream position, which broke the density SegmentInfo.merge asserts
     // on as soon as a consumer coalesced a batch (one commit spanning many positions).
@@ -233,8 +229,9 @@ pub fn append(self: *Self, changes: []const Change, options: WriteOptions) !Comm
     defer w.deinit();
     try msgpack.encode(Transaction{
         .id = commit_id,
-        .version = version,
-        .external = options.version != null,
+        // Stored as given: null for a local commit, so replay can tell the two apart
+        // without a second field that could contradict this one.
+        .version = options.version,
         .changes = changes,
     }, &w.writer);
     const payload = w.written();
@@ -251,7 +248,7 @@ pub fn append(self: *Self, changes: []const Change, options: WriteOptions) !Comm
 
     self.last_commit_id = commit_id;
     self.last_version = version;
-    if (options.version != null) self.external_versions = true;
+    if (options.version != null) self.saw_external = true;
     return .{ .commit_id = commit_id, .version = version };
 }
 

--- a/src/Oplog.zig
+++ b/src/Oplog.zig
@@ -59,6 +59,9 @@ current_size: usize = 0,
 write_offset: u64 = 0,
 last_commit_id: u64 = 0,
 last_version: u64 = 0,
+// Sticky: set once a commit carries an upstream position, restored on replay and
+// from the manifest. Once set, a positionless write is refused. See append().
+external_versions: bool = false,
 max_file_size: usize = default_max_file_size,
 
 fn buildName(buf: []u8, start: u64) []u8 {
@@ -146,6 +149,7 @@ fn replay(self: *Self, ctx: anytype, handler: anytype) !void {
                 .record => |txn| {
                     self.last_commit_id = @max(self.last_commit_id, txn.id);
                     self.last_version = @max(self.last_version, txn.version);
+                    if (txn.external) self.external_versions = true;
                     try handler(ctx, txn);
                     count += 1;
                 },
@@ -201,17 +205,36 @@ pub fn append(self: *Self, changes: []const Change, options: WriteOptions) !Comm
     if (options.expected_version) |expected| {
         if (self.last_version != expected) return error.VersionMismatch;
     }
+    // Once an index has taken a position from an upstream feed, every later commit
+    // needs one too. Minting a local version on top of upstream ones would invent a
+    // position the upstream never issued — and this node advertises that number as a
+    // watermark, so a peer bootstrapping from it would resume the feed at a position
+    // that does not exist and skip whatever really sits there.
+    if (self.external_versions and options.version == null) return error.VersionRequired;
+
     // Commit ids are always minted locally and densely. They used to be overridden
     // with the upstream position, which broke the density SegmentInfo.merge asserts
     // on as soon as a consumer coalesced a batch (one commit spanning many positions).
     const commit_id = self.last_commit_id + 1;
-    const version = options.version orelse commit_id;
+    // Without an upstream position, continue the version sequence rather than taking
+    // the commit id: on an index that has consumed a feed the two are far apart, and
+    // `orelse commit_id` would drag the version back to it.
+    const version = options.version orelse (self.last_version + 1);
+
+    // The version is a resume point and a watermark other nodes act on, so it must
+    // never go backwards: a regression makes a consumer re-read from an earlier
+    // position and makes this node advertise a watermark it has already passed.
+    // Non-decreasing rather than strictly increasing — several commits legitimately
+    // share one position when a bootstrap loads a snapshot taken at a single point.
+    // Checked before anything is written, so a rejected append leaves no trace.
+    if (version < self.last_version) return error.VersionWentBackwards;
 
     var w = std.Io.Writer.Allocating.init(self.allocator);
     defer w.deinit();
     try msgpack.encode(Transaction{
         .id = commit_id,
         .version = version,
+        .external = options.version != null,
         .changes = changes,
     }, &w.writer);
     const payload = w.written();
@@ -228,6 +251,7 @@ pub fn append(self: *Self, changes: []const Change, options: WriteOptions) !Comm
 
     self.last_commit_id = commit_id;
     self.last_version = version;
+    if (options.version != null) self.external_versions = true;
     return .{ .commit_id = commit_id, .version = version };
 }
 

--- a/src/Oplog.zig
+++ b/src/Oplog.zig
@@ -59,10 +59,6 @@ current_size: usize = 0,
 write_offset: u64 = 0,
 last_commit_id: u64 = 0,
 last_version: u64 = 0,
-// Whether any replayed transaction carried an upstream position. The Index combines
-// this with the manifest to decide whether the index is upstream-fed; the oplog itself
-// holds no policy.
-saw_external: bool = false,
 max_file_size: usize = default_max_file_size,
 
 fn buildName(buf: []u8, start: u64) []u8 {
@@ -152,7 +148,6 @@ fn replay(self: *Self, ctx: anytype, handler: anytype) !void {
                     // A locally-minted commit has no stored position: its version is
                     // its commit id, which is the standalone identity.
                     self.last_version = @max(self.last_version, txn.version orelse txn.id);
-                    if (txn.version != null) self.saw_external = true;
                     try handler(ctx, txn);
                     count += 1;
                 },
@@ -161,14 +156,14 @@ fn replay(self: *Self, ctx: anytype, handler: anytype) !void {
                     // A torn record can only be the tail (a crash mid-append writes
                     // the last record; nothing follows it). Recover the prefix and
                     // stop — a later append or the PG poller refills from here.
-                    log.warn("oplog: torn record in {s}, stopping replay at commit_id {d}", .{ name, self.last_commit_id });
+                    log.warn("oplog: torn record in {s}, stopping replay at commit {d}", .{ name, self.last_commit_id });
                     break :files;
                 },
             }
         }
     }
     if (count > 0) {
-        log.info("replayed {d} transactions, commit_id {d}", .{ count, self.last_commit_id });
+        log.info("replayed {d} transactions, commit {d}", .{ count, self.last_commit_id });
     }
 }
 
@@ -248,7 +243,6 @@ pub fn append(self: *Self, changes: []const Change, options: WriteOptions) !Comm
 
     self.last_commit_id = commit_id;
     self.last_version = version;
-    if (options.version != null) self.saw_external = true;
     return .{ .commit_id = commit_id, .version = version };
 }
 
@@ -287,6 +281,6 @@ pub fn truncate(self: *Self, commit_id: u64) !void {
         const remaining = self.files.items.len - deleted;
         std.mem.copyForwards(u64, self.files.items[0..remaining], self.files.items[deleted..]);
         self.files.shrinkRetainingCapacity(remaining);
-        log.info("truncated {d} oplog files below commit_id {d}", .{ deleted, commit_id });
+        log.info("truncated {d} oplog files below commit {d}", .{ deleted, commit_id });
     }
 }

--- a/src/change.zig
+++ b/src/change.zig
@@ -61,6 +61,10 @@ pub const Change = union(enum) {
 pub const Transaction = struct {
     id: u64,
     version: u64 = 0,
+    // Whether `version` came from an upstream feed rather than being minted locally.
+    // Replay uses it to restore the oplog's sticky external_versions flag, so the rule
+    // holds across a restart that happens before the next checkpoint.
+    external: bool = false,
     changes: []const Change,
 
     pub fn msgpackFormat() msgpack.StructFormat {

--- a/src/change.zig
+++ b/src/change.zig
@@ -60,11 +60,11 @@ pub const Change = union(enum) {
 // no upstream and the two are equal. See SegmentInfo for why they are separate.
 pub const Transaction = struct {
     id: u64,
-    version: u64 = 0,
-    // Whether `version` came from an upstream feed rather than being minted locally.
-    // Replay uses it to restore the oplog's sticky external_versions flag, so the rule
-    // holds across a restart that happens before the next checkpoint.
-    external: bool = false,
+    // The upstream position, or null when this commit was minted locally (standalone),
+    // in which case the version is the commit id. Optional rather than a value plus an
+    // "is it external" flag: the two can't then disagree, and replay recovers the
+    // upstream-fed marker from the same field.
+    version: ?u64 = null,
     changes: []const Change,
 
     pub fn msgpackFormat() msgpack.StructFormat {

--- a/src/change.zig
+++ b/src/change.zig
@@ -54,8 +54,13 @@ pub const Change = union(enum) {
     }
 };
 
+// One durable commit in the oplog. `id` is the internal commit id (dense, minted
+// locally); `version` is the upstream changelog position it corresponds to,
+// which is what a restarted node resumes the feed from. In standalone mode there is
+// no upstream and the two are equal. See SegmentInfo for why they are separate.
 pub const Transaction = struct {
     id: u64,
+    version: u64 = 0,
     changes: []const Change,
 
     pub fn msgpackFormat() msgpack.StructFormat {

--- a/src/common.zig
+++ b/src/common.zig
@@ -81,7 +81,9 @@ pub const SearchResults = struct {
     pool_next: ?*SearchResults = null, // intrusive free-list link, see SearchResultsPool
 
     const Hit = packed struct {
-        version: u64,
+        // The commit id of the segment this hit came from, NOT the external version:
+        // supersession is decided against segment identity. See SegmentInfo.
+        commit_id: u64,
         score: u32,
     };
 
@@ -116,12 +118,12 @@ pub const SearchResults = struct {
         }
     }
 
-    pub fn incr(self: *SearchResults, id: u32, version: u64) !void {
+    pub fn incr(self: *SearchResults, id: u32, commit_id: u64) !void {
         const r = try self.hits.getOrPut(self.allocator, id);
-        if (!r.found_existing or r.value_ptr.version < version) {
+        if (!r.found_existing or r.value_ptr.commit_id < commit_id) {
             r.value_ptr.score = 1;
-            r.value_ptr.version = version;
-        } else if (r.value_ptr.version == version) {
+            r.value_ptr.commit_id = commit_id;
+        } else if (r.value_ptr.commit_id == commit_id) {
             r.value_ptr.score += 1;
         }
     }
@@ -147,13 +149,13 @@ pub const SearchResults = struct {
         // Take the top-k in place: `out` only advances when a candidate survives, so
         // it never overtakes the read cursor and the survivors compact to the front.
         // The map is probed only for the candidates actually examined, for their
-        // version - the rest of the sorted tail is never touched.
+        // commit id - the rest of the sorted tail is never touched.
         var out: usize = 0;
         for (self.results.items) |candidate| {
             if (out == self.options.max_results) break;
             const hit = self.hits.get(candidate.id) orelse unreachable;
             // A hit from a superseded version of the doc: skip it, but keep scanning.
-            if (collection.hasNewerVersion(candidate.id, hit.version)) continue;
+            if (collection.hasNewerCommit(candidate.id, hit.commit_id)) continue;
             // Sorted by score descending, so nothing further can clear the bar.
             if (candidate.score < min_score) break;
             // Relative cutoff, anchored on the best score that actually survived.

--- a/src/filefmt.zig
+++ b/src/filefmt.zig
@@ -43,20 +43,24 @@ const segment_align: std.mem.Alignment = .fromByteUnits(64);
 
 pub fn buildSegmentFileName(buf: []u8, info: SegmentInfo) []u8 {
     assert(buf.len == max_file_name_size);
-    return std.fmt.bufPrint(buf, segment_file_name_fmt, .{ info.version, info.merges }) catch unreachable;
+    return std.fmt.bufPrint(buf, segment_file_name_fmt, .{ info.commit_id, info.merges }) catch unreachable;
 }
 
 pub fn isSegmentFileName(name: []const u8) bool {
     return parseSegmentFileName(name) != null;
 }
 
+/// Parse a segment file name back into its identity. The name encodes only the
+/// commit-id interval, so `version` comes back as 0 — this is a name check
+/// (see isSegmentFile), NOT a source of segment info. The manifest and the file
+/// header are; both carry the position.
 pub fn parseSegmentFileName(name: []const u8) ?SegmentInfo {
     if (!std.mem.endsWith(u8, name, segment_file_suffix)) return null;
     const s = name[0 .. name.len - segment_file_suffix.len];
     if (s.len != 25 or s[16] != '-') return null;
-    const version = std.fmt.parseUnsigned(u64, s[0..16], 16) catch return null;
+    const commit_id = std.fmt.parseUnsigned(u64, s[0..16], 16) catch return null;
     const merges = std.fmt.parseUnsigned(u32, s[17..25], 16) catch return null;
-    return SegmentInfo{ .version = version, .merges = merges };
+    return SegmentInfo{ .commit_id = commit_id, .merges = merges };
 }
 
 pub const SegmentFileHeader = struct {
@@ -298,7 +302,7 @@ test "segment round-trip: write, read, search" {
     const dir_path = "test_segment_roundtrip";
     cwd.createDir(dir_path, 0o755) catch {};
     var dir = try cwd.openDir(dir_path, .{});
-    const info: SegmentInfo = .{ .version = 1, .merges = 0 };
+    const info: SegmentInfo = .{ .commit_id = 1, .merges = 0 };
     defer {
         deleteSegmentFile(dir, info) catch {};
         dir.close();
@@ -322,7 +326,7 @@ test "segment round-trip: write, read, search" {
     try readSegment(dir, info, &seg);
 
     try std.testing.expectEqual(@as(usize, 2), seg.docs.count());
-    try std.testing.expectEqual(@as(u64, 1), seg.info.version);
+    try std.testing.expectEqual(@as(u64, 1), seg.info.commit_id);
     try std.testing.expectEqual(@as(usize, 5), seg.num_items);
 
     var results = SearchResults.init(std.testing.allocator, .{ .max_results = 10, .min_score = 1 });

--- a/src/manifest.zig
+++ b/src/manifest.zig
@@ -12,15 +12,27 @@ const log = std.log.scoped(.manifest);
 const manifest_file = "manifest";
 const manifest_tmp = "manifest.tmp";
 
-/// Read the manifest. Returns an owned slice (caller frees). Missing/empty
-/// manifest yields an empty slice.
-pub fn read(dir: zio.Dir, allocator: std.mem.Allocator) ![]SegmentInfo {
+/// What the manifest records beyond the segment list.
+pub const Manifest = struct {
+    segments: []SegmentInfo = &.{},
+    // Sticky marker that this index is fed by an upstream log; see Oplog.append.
+    // Durable here because the oplog is truncated at every checkpoint.
+    external_versions: bool = false,
+
+    pub fn msgpackFormat() msgpack.StructFormat {
+        return .{ .as_map = .{ .key = .{ .field_name_prefix = 1 } } };
+    }
+};
+
+/// Read the manifest. Segments are owned (caller frees). Missing/empty manifest
+/// yields an empty one.
+pub fn read(dir: zio.Dir, allocator: std.mem.Allocator) !Manifest {
     const st = dir.statPath(manifest_file) catch |err| switch (err) {
-        error.FileNotFound => return &.{},
+        error.FileNotFound => return .{},
         else => return err,
     };
     const size: usize = @intCast(st.size);
-    if (size == 0) return &.{};
+    if (size == 0) return .{};
 
     const file = try dir.openFile(manifest_file, .{ .mode = .read_only });
     defer file.close();
@@ -35,14 +47,14 @@ pub fn read(dir: zio.Dir, allocator: std.mem.Allocator) ![]SegmentInfo {
     }
 
     var reader = std.Io.Reader.fixed(buf[0..off]);
-    return try msgpack.decodeLeaky([]SegmentInfo, allocator, &reader);
+    return try msgpack.decodeLeaky(Manifest, allocator, &reader);
 }
 
-/// Atomically replace the manifest with `segments`.
-pub fn write(dir: zio.Dir, allocator: std.mem.Allocator, segments: []const SegmentInfo) !void {
+/// Atomically replace the manifest.
+pub fn write(dir: zio.Dir, allocator: std.mem.Allocator, m: Manifest) !void {
     var w = std.Io.Writer.Allocating.init(allocator);
     defer w.deinit();
-    try msgpack.encode(segments, &w.writer);
+    try msgpack.encode(m, &w.writer);
     const bytes = w.written();
 
     const file = try dir.createFile(manifest_tmp, .{ .truncate = true });

--- a/src/manifest.zig
+++ b/src/manifest.zig
@@ -12,27 +12,15 @@ const log = std.log.scoped(.manifest);
 const manifest_file = "manifest";
 const manifest_tmp = "manifest.tmp";
 
-/// What the manifest records beyond the segment list.
-pub const Manifest = struct {
-    segments: []SegmentInfo = &.{},
-    // Sticky marker that this index is fed by an upstream log; see Oplog.append.
-    // Durable here because the oplog is truncated at every checkpoint.
-    external_versions: bool = false,
-
-    pub fn msgpackFormat() msgpack.StructFormat {
-        return .{ .as_map = .{ .key = .{ .field_name_prefix = 1 } } };
-    }
-};
-
-/// Read the manifest. Segments are owned (caller frees). Missing/empty manifest
-/// yields an empty one.
-pub fn read(dir: zio.Dir, allocator: std.mem.Allocator) !Manifest {
+/// Read the manifest. Returns an owned slice (caller frees). Missing/empty
+/// manifest yields an empty slice.
+pub fn read(dir: zio.Dir, allocator: std.mem.Allocator) ![]SegmentInfo {
     const st = dir.statPath(manifest_file) catch |err| switch (err) {
-        error.FileNotFound => return .{},
+        error.FileNotFound => return &.{},
         else => return err,
     };
     const size: usize = @intCast(st.size);
-    if (size == 0) return .{};
+    if (size == 0) return &.{};
 
     const file = try dir.openFile(manifest_file, .{ .mode = .read_only });
     defer file.close();
@@ -47,14 +35,16 @@ pub fn read(dir: zio.Dir, allocator: std.mem.Allocator) !Manifest {
     }
 
     var reader = std.Io.Reader.fixed(buf[0..off]);
-    return try msgpack.decodeLeaky(Manifest, allocator, &reader);
+    return try msgpack.decodeLeaky([]SegmentInfo, allocator, &reader);
 }
 
-/// Atomically replace the manifest.
-pub fn write(dir: zio.Dir, allocator: std.mem.Allocator, m: Manifest) !void {
+/// Atomically replace the manifest with `segments`. Nothing index-level is stored:
+/// whether the index is upstream-fed is derivable from the segments themselves (any
+/// non-null SegmentInfo.version), so there is no separate flag to keep in sync.
+pub fn write(dir: zio.Dir, allocator: std.mem.Allocator, segments: []const SegmentInfo) !void {
     var w = std.Io.Writer.Allocating.init(allocator);
     defer w.deinit();
-    try msgpack.encode(m, &w.writer);
+    try msgpack.encode(segments, &w.writer);
     const bytes = w.written();
 
     const file = try dir.createFile(manifest_tmp, .{ .truncate = true });

--- a/src/segment.zig
+++ b/src/segment.zig
@@ -1,30 +1,47 @@
 const std = @import("std");
 const msgpack = @import("msgpack");
 
+// Identity of a segment, and what it covers.
+//
+// `commit_id`/`merges` are the INTERNAL commit-id interval [commit_id, commit_id+merges].
+// Commit ids are minted locally, one per index write, and are dense: segments tile
+// the sequence without gaps, which is what `merge` asserts on below and what
+// `contains` reasons about.
+//
+// `version` is the EXTERNAL position in the upstream changelog that this
+// segment's contents are complete up to. It is deliberately NOT the commit id: one
+// commit can cover many log positions (a consumer coalesces a batch and applies it
+// as one write) and many commits can share one log position (a bootstrap loads a
+// whole table snapshot taken at a single position). Conflating them forced the
+// external, arbitrarily-spaced position into a field that must be dense.
 pub const SegmentInfo = struct {
-    version: u64 = 0,
+    commit_id: u64 = 0,
     merges: u64 = 0,
+    version: u64 = 0,
 
     pub fn contains(self: SegmentInfo, other: SegmentInfo) bool {
-        const start = self.version;
-        const end = self.version + self.merges;
+        const start = self.commit_id;
+        const end = self.commit_id + self.merges;
 
-        const other_start = other.version;
-        const other_end = other.version + other.merges;
+        const other_start = other.commit_id;
+        const other_end = other.commit_id + other.merges;
 
         return other_start >= start and other_end <= end;
     }
 
     pub fn merge(self: SegmentInfo, other: SegmentInfo) SegmentInfo {
-        std.debug.assert(self.version + self.merges + 1 == other.version);
+        std.debug.assert(self.commit_id + self.merges + 1 == other.commit_id);
         return .{
-            .version = @min(self.version, other.version),
+            .commit_id = @min(self.commit_id, other.commit_id),
             .merges = self.merges + other.merges + 1,
+            // `other` is the internally-adjacent later segment, so its position is
+            // the newer one; @max states that without relying on the ordering.
+            .version = @max(self.version, other.version),
         };
     }
 
     pub fn getLastCommitId(self: SegmentInfo) u64 {
-        return self.version + self.merges;
+        return self.commit_id + self.merges;
     }
 
     pub fn msgpackFormat() msgpack.StructFormat {
@@ -33,9 +50,9 @@ pub const SegmentInfo = struct {
 };
 
 test "SegmentInfo.contains" {
-    const a = SegmentInfo{ .version = 1, .merges = 0 };
-    const b = SegmentInfo{ .version = 2, .merges = 0 };
-    const c = SegmentInfo{ .version = 1, .merges = 1 };
+    const a = SegmentInfo{ .commit_id = 1, .merges = 0 };
+    const b = SegmentInfo{ .commit_id = 2, .merges = 0 };
+    const c = SegmentInfo{ .commit_id = 1, .merges = 1 };
 
     try std.testing.expect(a.contains(a));
     try std.testing.expect(!a.contains(b));

--- a/src/segment.zig
+++ b/src/segment.zig
@@ -8,16 +8,22 @@ const msgpack = @import("msgpack");
 // the sequence without gaps, which is what `merge` asserts on below and what
 // `contains` reasons about.
 //
-// `version` is the EXTERNAL position in the upstream changelog that this
-// segment's contents are complete up to. It is deliberately NOT the commit id: one
-// commit can cover many log positions (a consumer coalesces a batch and applies it
-// as one write) and many commits can share one log position (a bootstrap loads a
-// whole table snapshot taken at a single position). Conflating them forced the
-// external, arbitrarily-spaced position into a field that must be dense.
+// `version` is the EXTERNAL position in the upstream changelog that this segment's
+// contents are complete up to — the number everything outside the index means by
+// "version", including the API. It is deliberately NOT the commit id: one commit can
+// cover many positions (a consumer coalesces a batch and applies it as one write) and
+// many commits can share one position (a bootstrap loads a whole table snapshot taken
+// at a single position). Conflating them forced the external, arbitrarily-spaced
+// position into a field that must be dense.
+//
+// null means the contents were never given an upstream position — written locally in
+// standalone mode, where a commit's version IS its commit id, so `effectiveVersion`
+// falls back to that. A non-null version on ANY segment is also what marks the whole
+// index as upstream-fed; there is no separate flag to keep in sync. See Index.update.
 pub const SegmentInfo = struct {
     commit_id: u64 = 0,
     merges: u64 = 0,
-    version: u64 = 0,
+    version: ?u64 = null,
 
     pub fn contains(self: SegmentInfo, other: SegmentInfo) bool {
         const start = self.commit_id;
@@ -34,14 +40,25 @@ pub const SegmentInfo = struct {
         return .{
             .commit_id = @min(self.commit_id, other.commit_id),
             .merges = self.merges + other.merges + 1,
-            // `other` is the internally-adjacent later segment, so its position is
-            // the newer one; @max states that without relying on the ordering.
-            .version = @max(self.version, other.version),
+            // `other` is the internally-adjacent later segment, so its position is the
+            // newer one. Keep whichever side has a position at all: a merge of local
+            // and upstream-fed segments stays marked as upstream-fed.
+            .version = if (other.version) |b|
+                if (self.version) |a| @max(a, b) else b
+            else
+                self.version,
         };
     }
 
     pub fn getLastCommitId(self: SegmentInfo) u64 {
         return self.commit_id + self.merges;
+    }
+
+    /// The version to report for this segment. With no upstream position the commit id
+    /// is the version — they are identical for an index that has only ever been
+    /// standalone, which is exactly when `version` is null.
+    pub fn effectiveVersion(self: SegmentInfo) u64 {
+        return self.version orelse self.getLastCommitId();
     }
 
     pub fn msgpackFormat() msgpack.StructFormat {

--- a/src/segment_merger.zig
+++ b/src/segment_merger.zig
@@ -1,6 +1,6 @@
-// k-way merge of several segments into one. For each doc, the newest version
+// k-way merge of several segments into one. For each doc, the newest commit_id
 // wins (docs shadowed by a segment newer than their own are skipped, resolved
-// via the collection's hasNewerVersion); deleted docs keep a tombstone in the
+// via the collection's hasNewerCommit); deleted docs keep a tombstone in the
 // merged docs map so they keep shadowing older versions. The result is a reader
 // (read/advance + `.segment`) that filefmt.writeSegment can consume directly.
 
@@ -81,7 +81,7 @@ pub fn SegmentMerger(comptime Segment: type) type {
             self.sources.appendAssumeCapacity(.{ .reader = source.reader() });
         }
 
-        /// `collection` must expose `hasNewerVersion(doc_id, version) bool`.
+        /// `collection` must expose `hasNewerCommit(doc_id, commit_id) bool`.
         pub fn prepare(self: *Self, collection: anytype) !void {
             const sources = self.sources.items;
             if (sources.len == 0) return error.NoSources;
@@ -112,7 +112,7 @@ pub fn SegmentMerger(comptime Segment: type) type {
                     docs_found += 1;
                     const doc_id = entry.key_ptr.*;
                     const doc_status = entry.value_ptr.*;
-                    if (!collection.hasNewerVersion(doc_id, segment.info.version)) {
+                    if (!collection.hasNewerCommit(doc_id, segment.info.commit_id)) {
                         try self.segment.docs.put(self.allocator, doc_id, doc_status);
                         docs_added += 1;
                         if (self.segment.min_doc_id == 0 or doc_id < self.segment.min_doc_id) self.segment.min_doc_id = doc_id;

--- a/src/snapshot.zig
+++ b/src/snapshot.zig
@@ -1,7 +1,7 @@
 // Node-to-node snapshot: an index's file segments + a manifest, with NO WAL and NO
 // in-memory segments. It's how a new or behind replica bootstraps without replaying the
 // whole changelog (see notes/bootstrap-design.md): restore it, then resume the tail
-// from the coordinator at the embedded watermark (= max segment version).
+// from the coordinator at the embedded watermark (= max segment commit_id).
 //
 // Wire form: a single msgpack `SnapshotHeader` (self-delimiting, so the reader lands
 // exactly on the first payload byte), then each file segment's raw bytes concatenated
@@ -84,7 +84,7 @@ pub fn parse(arena: std.mem.Allocator, bytes: []const u8) !Parsed {
 // manifest from the header, then stream each segment payload straight to its file (no
 // whole-archive buffering). Verifies the snapshot's generation is `expected_generation`
 // — the lineage the caller means to restore. The watermark isn't returned; the caller
-// opens the index, which derives its version from the restored manifest.
+// opens the index, which derives its commit_id from the restored manifest.
 pub fn restoreInto(dir: zio.Dir, r: *std.Io.Reader, arena: std.mem.Allocator, expected_generation: u64) !void {
     const unpacker = msgpack.unpacker(r, arena);
     const header = try unpacker.read(SnapshotHeader);

--- a/src/snapshot.zig
+++ b/src/snapshot.zig
@@ -1,7 +1,9 @@
 // Node-to-node snapshot: an index's file segments + a manifest, with NO WAL and NO
 // in-memory segments. It's how a new or behind replica bootstraps without replaying the
 // whole changelog (see notes/bootstrap-design.md): restore it, then resume the tail
-// from the coordinator at the embedded watermark (= max segment commit_id).
+// from the coordinator at the embedded watermark — the max segment `version`, which is
+// the external feed position. The segments also carry their internal commit ids, which
+// order them locally but mean nothing to the coordinator.
 //
 // Wire form: a single msgpack `SnapshotHeader` (self-delimiting, so the reader lands
 // exactly on the first payload byte), then each file segment's raw bytes concatenated
@@ -84,7 +86,8 @@ pub fn parse(arena: std.mem.Allocator, bytes: []const u8) !Parsed {
 // manifest from the header, then stream each segment payload straight to its file (no
 // whole-archive buffering). Verifies the snapshot's generation is `expected_generation`
 // — the lineage the caller means to restore. The watermark isn't returned; the caller
-// opens the index, which derives its commit_id from the restored manifest.
+// opens the index, which derives both the resume position and the commit ids from the
+// restored manifest.
 pub fn restoreInto(dir: zio.Dir, r: *std.Io.Reader, arena: std.mem.Allocator, expected_generation: u64) !void {
     const unpacker = msgpack.unpacker(r, arena);
     const header = try unpacker.read(SnapshotHeader);
@@ -93,8 +96,6 @@ pub fn restoreInto(dir: zio.Dir, r: *std.Io.Reader, arena: std.mem.Allocator, ex
 
     const infos = try arena.alloc(SegmentInfo, header.segments.len);
     for (header.segments, 0..) |seg, i| infos[i] = seg.info;
-    // The segments carry their own versions, so a restored index inherits the donor's
-    // upstream-fed state without the snapshot needing to say so separately.
     try manifest.write(dir, arena, infos);
 
     const scratch = try arena.alloc(u8, 128 * 1024);

--- a/src/snapshot.zig
+++ b/src/snapshot.zig
@@ -36,9 +36,6 @@ pub const SnapshotHeader = struct {
     format: u32 = format_version,
     generation: u64,
     segments: []SegmentEntry,
-    // Carried so a restored index keeps the donor's "fed by an upstream" marker
-    // instead of the restorer having to guess it. See Oplog.append.
-    external_versions: bool = false,
 
     pub fn msgpackFormat() msgpack.StructFormat {
         return .{ .as_map = .{ .key = .{ .field_name_prefix = 1 } } };
@@ -54,11 +51,7 @@ pub fn writeSnapshot(w: *std.Io.Writer, arena: std.mem.Allocator, segs: *const S
 
     var hbuf: std.Io.Writer.Allocating = .init(arena);
     defer hbuf.deinit();
-    try msgpack.encode(SnapshotHeader{
-        .generation = generation,
-        .segments = entries,
-        .external_versions = segs.external_versions,
-    }, &hbuf.writer);
+    try msgpack.encode(SnapshotHeader{ .generation = generation, .segments = entries }, &hbuf.writer);
     try w.writeAll(hbuf.written());
 
     for (segs.file) |s| {
@@ -100,7 +93,9 @@ pub fn restoreInto(dir: zio.Dir, r: *std.Io.Reader, arena: std.mem.Allocator, ex
 
     const infos = try arena.alloc(SegmentInfo, header.segments.len);
     for (header.segments, 0..) |seg, i| infos[i] = seg.info;
-    try manifest.write(dir, arena, .{ .segments = infos, .external_versions = header.external_versions });
+    // The segments carry their own versions, so a restored index inherits the donor's
+    // upstream-fed state without the snapshot needing to say so separately.
+    try manifest.write(dir, arena, infos);
 
     const scratch = try arena.alloc(u8, 128 * 1024);
     for (header.segments) |seg| {

--- a/src/snapshot.zig
+++ b/src/snapshot.zig
@@ -36,6 +36,9 @@ pub const SnapshotHeader = struct {
     format: u32 = format_version,
     generation: u64,
     segments: []SegmentEntry,
+    // Carried so a restored index keeps the donor's "fed by an upstream" marker
+    // instead of the restorer having to guess it. See Oplog.append.
+    external_versions: bool = false,
 
     pub fn msgpackFormat() msgpack.StructFormat {
         return .{ .as_map = .{ .key = .{ .field_name_prefix = 1 } } };
@@ -51,7 +54,11 @@ pub fn writeSnapshot(w: *std.Io.Writer, arena: std.mem.Allocator, segs: *const S
 
     var hbuf: std.Io.Writer.Allocating = .init(arena);
     defer hbuf.deinit();
-    try msgpack.encode(SnapshotHeader{ .generation = generation, .segments = entries }, &hbuf.writer);
+    try msgpack.encode(SnapshotHeader{
+        .generation = generation,
+        .segments = entries,
+        .external_versions = segs.external_versions,
+    }, &hbuf.writer);
     try w.writeAll(hbuf.written());
 
     for (segs.file) |s| {
@@ -93,7 +100,7 @@ pub fn restoreInto(dir: zio.Dir, r: *std.Io.Reader, arena: std.mem.Allocator, ex
 
     const infos = try arena.alloc(SegmentInfo, header.segments.len);
     for (header.segments, 0..) |seg, i| infos[i] = seg.info;
-    try manifest.write(dir, arena, infos);
+    try manifest.write(dir, arena, .{ .segments = infos, .external_versions = header.external_versions });
 
     const scratch = try arena.alloc(u8, 128 * 1024);
     for (header.segments) |seg| {


### PR DESCRIPTION
Splits the upstream changelog position out of the internal commit id. Fixes a panic that replication can hit today.

## The bug

`SegmentInfo.version`/`merges` is a commit-id **interval** — a segment covers `[version, version+merges]` — and `SegmentInfo.merge` asserts exact adjacency:

```zig
std.debug.assert(self.version + self.merges + 1 == other.version);
```

Segments must tile that sequence densely. But the upstream changelog position was written straight into it, and the two have different shapes.

They diverge the moment a consumer coalesces a batch. `Replicator.consumeLoop` applies a run of feed entries as one commit at `version = buf[n - 1].id`, the **max** seq of the batch. So a batch covering seqs 1–10 is recorded as `{version: 10, merges: 0}` — an interval of one, sitting at the end of a range of ten. The next batch lands at 20, adjacency requires `11 == 20`, and merging those segments panics:

```
thread panic: reached unreachable code
    std.debug.assert(self.version + self.merges + 1 == other.version);
```

Every existing test applies a single change per update, which happens to make positions dense (1, 2, 3…), so nothing caught it. Under replication with `batch_size = 256` and a busy feed it fires. Built with ReleaseFast there is no assert at all and `SegmentInfo.contains` silently returns wrong answers instead, which feeds `hasNewerVersion` during merges.

Reproduced on `ng` before the fix by applying with position jumps of 10 and forcing a memory merge; that scenario is now a regression test.

## The split

**`SegmentInfo.commit_id`** (+ `merges`) is the internal interval. Commit ids are always minted locally and densely (`last + 1`); `Oplog.append` no longer accepts an externally-assigned one. Segment identity, adjacency, `contains()`, oplog file naming and replay filtering are unchanged.

**`SegmentInfo.version`** is the upstream changelog position that segment's contents are complete up to. Many commits can share one (a bootstrap loading a table snapshot taken at a single position) and one commit can cover many (a coalesced batch). Merging takes the max.

The names follow what each half already was. `getLastCommitId()` and the `Oplog` header called the internal one a commit id before this change — now the field agrees. And the external one keeps `version`, which is what the API has always reported, so **nothing user-visible changes meaning**.

`Index` tracks both pairs:

| | internal | external |
|---|---|---|
| newest committed | `commit_id` | `version` — the resume point |
| newest durable in a file segment | `file_commit_id` — replay/truncation key | `file_version` — what a snapshot carries |

A snapshot holds file segments only, so an uncheckpointed write moves the resume point without moving the watermark a fetcher would resume from. Both externals are recovered on open from the manifest plus the replayed WAL tail, derived independently of the commit ids.

Two names followed the field. `Segments.hasNewerVersion` → **`hasNewerCommit`**: it compares segment commit ids to decide supersession during merges and search, never positions. And `SearchResults.Hit.version` → **`commit_id`**, since a hit records which segment it came from. Those were the last two places where `version` still meant a commit id — leaving them would invite someone to "fix" the call by passing the external version, which would silently break search supersession. `DocInfo.version` is deliberately untouched: it is the user-facing number and correctly reports the position.

The `Oplog` header previously stated the conflation as intent — *"The commit id is the index version (log-position-as-version)"* — and is rewritten rather than left half-true.

Everything user-facing keeps meaning the *position*: the `_update` response, index info, per-document version, the read-your-writes wait, and the watermarks a replica reports. In standalone mode there is no upstream, a commit takes its own id as its position, and all of this behaves exactly as before.

## Enforcing what the version means (second commit)

Splitting the version out left it unvalidated — `Oplog.append` took whatever position it was handed. Two ways that goes wrong, both ending with this node advertising a watermark that doesn't mean what a peer will assume:

**Backwards.** A regression makes a consumer re-read from an earlier position and makes this node advertise a point it has already passed. Now `error.VersionWentBackwards`, checked before anything is written so a rejected append leaves no trace. Non-decreasing rather than strictly increasing — several commits legitimately share one position when a bootstrap loads a snapshot taken at a single point.

**Invented.** `orelse commit_id` meant a positionless write on an index fed by a changelog took the *commit id* as its version, dragging it from (say) 5000 back to 42. Worse than a regression: it mints a position the upstream never issued, and a peer bootstrapping from this node would resume the feed there and skip whatever really sits at that position.

So an index that has ever taken an upstream position now requires one for every later commit (`error.VersionRequired`). The marker is sticky and durable in **two** places, because neither alone survives:

- the oplog `Transaction` records whether its version came from upstream, so replay restores the marker after a crash before the next checkpoint;
- the manifest records it too, because a checkpoint *truncates the oplog that carried it* — without this, an index whose data is fully checkpointed would come back believing it had never had an upstream.

A snapshot carries the marker in its header, so a restored index inherits the donor's state rather than the restorer guessing.

Standalone is unchanged: with no upstream a commit takes the next version in sequence, which for an always-standalone index is exactly its commit id.

## Format change

`SegmentInfo` gains a third array element, the oplog `Transaction` two fields, the snapshot header one, and the manifest becomes a struct (segment list plus index-level state) rather than a bare array. No compatibility shim, per the rewrite's stated policy — existing data directories are not readable and should be rebuilt.

## Not covered

- `parseSegmentFileName` returns `version = 0`, since the name encodes only the commit-id interval. It is used solely as a name check (`isSegmentFile`); documented in place so it isn't later mistaken for a source of segment info.
- Expect a small conflict with #148, which touches the same watermark reporting in `MultiIndex`/`Replicator`. Kept independent of it deliberately: this is a correctness fix and shouldn't wait behind a feature branch.

## Testing

- `zig build unit-tests` — **78/78 pass** (74 before, plus four new): one drives coalesced batches through a merge and asserts the merged segments still tile the commit-id sequence without gaps; one checks the position survives checkpoint and restart, that a memory-only write moves the resume point but not the donor watermark, and that a replayed doc keeps its position; one covers monotonicity, the equal-position case, and that the sticky marker survives both a restart and a checkpoint that truncates the WAL; one pins that a standalone index still mints version == commit id.
- `zig build e2e-tests` — **48/48 pass**, the full `ng` baseline.
- `zig fmt --check src/` clean.

The e2e suite earned its keep here: it caught that the oplog replay path rebuilt segment info by hand and dropped the new field, which would have silently reported every replayed document at position 0. My unit test had missed it.
