### PR TITLE
Fill an empty node from the feed's corpus stream

### DIFF
--- a/notes/bootstrap-design.md
+++ b/notes/bootstrap-design.md
@@ -134,6 +134,13 @@ Node side:
   Same reasoning caps the cold-start story: bring nodes up one at a time on first fill,
   since concurrently-started empty nodes cannot see each other as donors until one
   finishes.
+- **Health and search say so.** While a consumer fills its index by bootstrap — the
+  initial seed and a below-retention restore alike — `/:index/_health` answers 503
+  `LOADING` and `/:index/_search` refuses with 503 (`IndexNotReady`), instead of
+  returning honest-looking but empty or stale results. The flag is sticky across
+  failed bootstrap attempts, so the gap between retries never flashes OK. Global
+  `/_health` and `/:index/_status` stay independent of it — peer discovery must keep
+  finding open-but-loading nodes, per the Kubernetes trap above.
 
 ## Milestones
 

--- a/notes/bootstrap-design.md
+++ b/notes/bootstrap-design.md
@@ -102,6 +102,39 @@ generation match) → atomically rename into `v<generation>` → open → resume
 Also: `position > max(id)` (PG lost an acked tail after async failover) → refuse to serve,
 rebuild. Prevented almost entirely by synchronous replication.
 
+## Source bootstrap (2026-07-30)
+
+Peer snapshots cover a node that is *behind*; nothing above covered the node that has
+*nothing* when the log itself is incomplete: the PG changelog starts at the migration,
+so replaying it from 0 builds an index silently missing every fingerprint that already
+existed — while being told "caught up". acoustid-server#242 adds
+`GET /_bootstrap/{index}/{generation}` for exactly this: a msgpack header carrying
+`position`, then arrays of `Change`, terminated by an empty array (the in-band
+done-versus-died signal; EOF without it is truncation, never completion).
+
+Node side:
+
+- **The capability is the feed's declaration.** `Coordinator.openBootstrap` is an
+  optional vtable op: implementing it says "my history starts later than my corpus, an
+  empty index must not replay from 0". The file log doesn't implement it; the memory
+  coordinator and `RemoteCoordinator` do (`coordinator_server` serves the same wire
+  shape as the PG feed, so the e2e suite exercises the real client path).
+- **An empty consumer seeds before its first read**, in preference order: peer snapshot
+  (the corpus already built inside the cluster beats pulling a terabyte from PG), then
+  the source stream, else plain replay from 0. One node pays for the stream once per
+  cluster; it flushes fully, so it immediately becomes a donor for the rest.
+- **Staging + swap, never in place.** The stream applies into `v<gen>/bootstrap.tmp` at
+  the single `position`, is fully flushed (`Index.flush`, threshold notwithstanding),
+  and installs through the same drain-and-swap path as a snapshot restore. Dying at 1%
+  leaves a tmp dir the next attempt deletes — not a node claiming `position` with 1% of
+  the data and a feed that will never re-send the rest.
+- **Deliberately not wired to the below-retention path.** A whole cluster falling off
+  the log would stampede the source with N corpus streams. That remedy stays
+  operator-driven: wipe one node — which makes it empty and lands it in the seed path.
+  Same reasoning caps the cold-start story: bring nodes up one at a time on first fill,
+  since concurrently-started empty nodes cannot see each other as donors until one
+  finishes.
+
 ## Milestones
 
 1. **Age-based checkpoint — DONE.** `Index.checkpoint_age` forces a flush once the oldest

--- a/src/Coordinator.zig
+++ b/src/Coordinator.zig
@@ -124,6 +124,45 @@ pub const MetaDeleteResponse = struct {
     }
 };
 
+/// First value in a bootstrap stream (see `openBootstrap`). `position` is the feed
+/// position the streamed state corresponds to, read before the first change; the
+/// consumer applies the whole stream at this one position and resumes the feed from it.
+pub const BootstrapHeader = struct {
+    position: u64,
+
+    pub fn msgpackFormat() msgpack.StructFormat {
+        return .{ .as_map = .{ .key = .{ .field_name_prefix = 1 } } };
+    }
+};
+
+/// A lineage's whole current state, streamed in batches — what `openBootstrap`
+/// returns. Exists for feeds whose history starts later than their corpus (the PG
+/// changelog begins at the migration), where replaying the data feed from 0 would
+/// build an index silently missing everything older.
+pub const BootstrapStream = struct {
+    ptr: *anyopaque,
+    vtable: *const VTable,
+    /// The feed position to resume from once the stream is applied.
+    position: u64,
+
+    pub const VTable = struct {
+        /// The next batch of changes, or null once the stream has properly ended.
+        /// A truncated stream is an error, never null — the transport must be able
+        /// to tell "done" from "died", or a partial corpus would install as
+        /// complete. Returned changes are valid until the next call.
+        next: *const fn (ptr: *anyopaque) anyerror!?[]const Change,
+        deinit: *const fn (ptr: *anyopaque) void,
+    };
+
+    pub fn next(self: *BootstrapStream) !?[]const Change {
+        return self.vtable.next(self.ptr);
+    }
+
+    pub fn deinit(self: *BootstrapStream) void {
+        self.vtable.deinit(self.ptr);
+    }
+};
+
 // Peer discovery for snapshot bootstrap is deliberately NOT here. Nodes find donors
 // among themselves from a configured list of peer URLs — see peers.zig. A registry on
 // this side would make the log implementation stateful, and so a singleton: two
@@ -167,6 +206,15 @@ pub const Coordinator = struct {
         /// a `read(after < floor)` returns error.BelowRetention. The PG impl derives this
         /// from real retention; the stub takes it explicitly (admin/tests).
         setRetentionFloor: *const fn (ptr: *anyopaque, index_name: []const u8, generation: u64, floor: u64) anyerror!void,
+
+        /// Stream the lineage's whole current state, for a node that has nothing.
+        /// Optional: null declares the feed's history complete from 0, so an empty
+        /// index simply replays (the file log, the memory stub before truncation).
+        /// A feed that DOES implement this declares the opposite — its history
+        /// starts later than its corpus — and an empty index must bootstrap here
+        /// (or from a peer) instead of replaying, or it silently misses everything
+        /// older than the log. Caller must stream.deinit().
+        openBootstrap: ?*const fn (ptr: *anyopaque, index_name: []const u8, generation: u64) anyerror!BootstrapStream = null,
     };
 
     pub fn append(self: Coordinator, index_name: []const u8, generation: u64, changes: []const Change, expected: ?u64) !u64 {
@@ -191,6 +239,13 @@ pub const Coordinator = struct {
 
     pub fn setRetentionFloor(self: Coordinator, index_name: []const u8, generation: u64, floor: u64) !void {
         return self.vtable.setRetentionFloor(self.ptr, index_name, generation, floor);
+    }
+
+    /// Open a bootstrap stream, or null when this feed does not offer one (its
+    /// history is complete from 0 and replay is the bootstrap).
+    pub fn openBootstrap(self: Coordinator, index_name: []const u8, generation: u64) !?BootstrapStream {
+        const f = self.vtable.openBootstrap orelse return null;
+        return try f(self.ptr, index_name, generation);
     }
 };
 
@@ -253,11 +308,75 @@ pub const MemoryCoordinator = struct {
         .deleteIndex = deleteIndexImpl,
         .readMeta = readMetaImpl,
         .setRetentionFloor = setRetentionFloorImpl,
+        .openBootstrap = openBootstrapImpl,
     };
 
     fn setRetentionFloorImpl(ptr: *anyopaque, index_name: []const u8, generation: u64, floor: u64) anyerror!void {
         const self: *MemoryCoordinator = @ptrCast(@alignCast(ptr));
         return self.setRetentionFloor(index_name, generation, floor);
+    }
+
+    // The stub's bootstrap: the lineage's changes, copied out under the mutex at open
+    // (so later appends can't shift the borrowed slices), served in batches, at
+    // position = the lineage's current max seq. Deliberately ignores the retention
+    // floor — a bootstrap is the CURRENT state, which retention never touches; it is
+    // exactly what a reader stuck below the floor is sent here to get.
+    const MemoryBootstrapStream = struct {
+        allocator: std.mem.Allocator,
+        arena: std.heap.ArenaAllocator,
+        changes: []Change,
+        served: usize = 0,
+
+        const batch = 256;
+
+        const stream_vtable: BootstrapStream.VTable = .{
+            .next = nextImpl,
+            .deinit = deinitImpl,
+        };
+
+        fn nextImpl(ptr: *anyopaque) anyerror!?[]const Change {
+            const self: *MemoryBootstrapStream = @ptrCast(@alignCast(ptr));
+            if (self.served >= self.changes.len) return null;
+            const n = @min(batch, self.changes.len - self.served);
+            const out = self.changes[self.served .. self.served + n];
+            self.served += n;
+            return out;
+        }
+
+        fn deinitImpl(ptr: *anyopaque) void {
+            const self: *MemoryBootstrapStream = @ptrCast(@alignCast(ptr));
+            const allocator = self.allocator;
+            self.arena.deinit();
+            allocator.destroy(self);
+        }
+    };
+
+    fn openBootstrapImpl(ptr: *anyopaque, index_name: []const u8, generation: u64) anyerror!BootstrapStream {
+        const self: *MemoryCoordinator = @ptrCast(@alignCast(ptr));
+        try self.mutex.lock();
+        defer self.mutex.unlock();
+
+        const ctx = try self.allocator.create(MemoryBootstrapStream);
+        errdefer self.allocator.destroy(ctx);
+        ctx.* = .{
+            .allocator = self.allocator,
+            .arena = std.heap.ArenaAllocator.init(self.allocator),
+            .changes = &.{},
+        };
+        errdefer ctx.arena.deinit();
+        const a = ctx.arena.allocator();
+
+        var list: std.ArrayListUnmanaged(Change) = .empty;
+        var position: u64 = 0;
+        for (self.rows.items) |row| { // append order == per-lineage seq order
+            if (row.generation != generation) continue;
+            if (!std.mem.eql(u8, row.index_name, index_name)) continue;
+            try list.append(a, try dupeChange(a, row.change));
+            position = row.seq;
+        }
+        ctx.changes = list.items;
+
+        return .{ .ptr = ctx, .vtable = &MemoryBootstrapStream.stream_vtable, .position = position };
     }
 
     fn appendImpl(ptr: *anyopaque, index_name: []const u8, generation: u64, changes: []const Change, expected: ?u64) anyerror!u64 {
@@ -617,6 +736,40 @@ test "MemoryCoordinator: meta feed create/delete/create, distinct generations, i
 
     // Deleting a name that isn't active is a no-op: returns the latest meta pos.
     try testing.expectEqual(other, try co.deleteIndex("does_not_exist"));
+}
+
+test "MemoryCoordinator: bootstrap streams the whole lineage state, retention notwithstanding" {
+    const rt = try zio.Runtime.init(testing.allocator, .{});
+    defer rt.deinit();
+
+    var cl = MemoryCoordinator.init(testing.allocator);
+    defer cl.deinit();
+    const co = cl.coordinator();
+
+    _ = try co.append("main", 1, &.{ ins(1, &.{10}), ins(2, &.{20}), ins(3, &.{30}) }, null);
+    // The floor makes read(after=0) impossible — which is exactly when a node needs
+    // the bootstrap, so the bootstrap must not be subject to it: it streams current
+    // state, and retention only ever drops history.
+    try cl.setRetentionFloor("main", 1, 2);
+
+    var stream = (try co.openBootstrap("main", 1)).?;
+    defer stream.deinit();
+    try testing.expectEqual(@as(u64, 3), stream.position);
+
+    var ids: std.ArrayListUnmanaged(u32) = .empty;
+    defer ids.deinit(testing.allocator);
+    while (try stream.next()) |changes| {
+        for (changes) |change| try ids.append(testing.allocator, change.insert.id);
+    }
+    try testing.expectEqualSlices(u32, &.{ 1, 2, 3 }, ids.items);
+    try testing.expectEqual(@as(?[]const Change, null), try stream.next()); // stays ended
+
+    // A lineage with no data: position 0, nothing streamed — the caller's signal
+    // that there is nothing before the log and plain replay is correct.
+    var empty = (try co.openBootstrap("main", 9)).?;
+    defer empty.deinit();
+    try testing.expectEqual(@as(u64, 0), empty.position);
+    try testing.expectEqual(@as(?[]const Change, null), try empty.next());
 }
 
 test "MemoryCoordinator: read below the retention floor signals bootstrap" {

--- a/src/Index.zig
+++ b/src/Index.zig
@@ -622,10 +622,19 @@ fn maintenanceLoop(self: *Self) zio.Cancelable!void {
 pub fn runMaintenance(self: *Self) !void {
     while (true) {
         if (try self.mergeMemory()) continue;
-        if (try self.checkpoint()) continue;
+        if (try self.checkpoint(false)) continue;
         if (try self.mergeFiles()) continue;
         break;
     }
+}
+
+/// Flush every memory segment to a file segment regardless of threshold or age, so
+/// everything the index holds is durable on disk. A bootstrap build needs this before
+/// its staging directory is swapped in: the swap path reopens from disk alone, and
+/// whatever only lived in memory would silently vanish from the installed index.
+pub fn flush(self: *Self) !void {
+    while (try self.mergeMemory()) {}
+    _ = try self.checkpoint(true);
 }
 
 fn memorySize(memory: []const MemoryRef) usize {
@@ -748,7 +757,7 @@ fn mergeMemory(self: *Self) !bool {
 // write lock; only the manifest write + snapshot swap hold it, so updates keep
 // flowing. Updates that arrive during the merge stay in memory (they append to
 // the suffix; the flushed segments are the prefix). Returns true if it ran.
-fn checkpoint(self: *Self) !bool {
+fn checkpoint(self: *Self, force: bool) !bool {
     try self.segments_lock.lockShared();
     var snap = self.segments.acquire();
     self.segments_lock.unlockShared();
@@ -771,7 +780,7 @@ fn checkpoint(self: *Self) !bool {
         self.pending_since.?.untilNow(.monotonic).toNanoseconds() >= age.toNanoseconds()
     else
         false;
-    if (!over_threshold and !aged) return false;
+    if (!force and !over_threshold and !aged) return false;
 
     var fseg = try self.mergeToFileSegment(MemorySegment, snap.value.memory, snap.value);
     var committed = false;
@@ -1065,6 +1074,33 @@ test "age-based checkpoint flushes a small pending batch" {
     var r = try index.acquireReader();
     defer r.deinit();
     try std.testing.expectEqual(@as(usize, 0), r.snapshot.value.memory.len);
+}
+
+test "flush checkpoints a batch the threshold and age triggers would both skip" {
+    const rt = try zio.Runtime.init(std.testing.allocator, .{});
+    defer rt.deinit();
+
+    const cwd = zio.Dir.cwd();
+    const dir_path = "test_index_flush";
+    cleanupTestDir(cwd, dir_path);
+    try cwd.createDir(dir_path, 0o755);
+    defer cleanupTestDir(cwd, dir_path);
+
+    const dir = try cwd.openDir(dir_path, .{ .iterate = true });
+    // High size threshold, no age trigger: nothing but flush() can checkpoint this.
+    var index = try Self.open(std.testing.allocator, dir, 100_000, true, null);
+    defer index.deinit();
+
+    _ = try index.update(&[_]Change{.{ .insert = .{ .id = 1, .hashes = &[_]u32{ 100, 200 } } }}, .{ .version = 7 });
+    try index.flush();
+
+    var r = try index.acquireReader();
+    defer r.deinit();
+    try std.testing.expectEqual(@as(usize, 0), r.snapshot.value.memory.len);
+    try std.testing.expectEqual(@as(usize, 1), r.snapshot.value.file.len);
+    // The upstream position is now durable in a file segment — what a bootstrap
+    // install (which reopens from disk alone) resumes the feed from.
+    try std.testing.expectEqual(@as(u64, 7), r.snapshot.value.file_version);
 }
 
 test "snapshot archive round-trips manifest + file segments" {

--- a/src/MultiIndex.zig
+++ b/src/MultiIndex.zig
@@ -19,6 +19,7 @@ const Metadata = @import("change.zig").Metadata;
 const MetadataEntry = @import("change.zig").MetadataEntry;
 const Replicator = @import("Replicator.zig");
 const Coordinator = @import("Coordinator.zig").Coordinator;
+const BootstrapStream = @import("Coordinator.zig").BootstrapStream;
 const index_redirect = @import("index_redirect.zig");
 const deleteDirTree = @import("common.zig").deleteDirTree;
 const SearchResultsPool = @import("common.zig").SearchResultsPool;
@@ -596,6 +597,79 @@ pub fn bootstrapLineage(self: *Self, name: []const u8, generation: u64, reader: 
     }
 
     // 2. Swap it in and reopen the index in place (under the lock, draining borrows).
+    return self.installBootstrap(name, generation, name_dir, vdir_name, vdir);
+}
+
+const bootstrap_build_tmp = "bootstrap.tmp";
+
+/// Bootstrap the (`name`, `generation`) lineage from the feed's own corpus stream
+/// (Coordinator.openBootstrap): build a staging index next to the live one, apply
+/// every batch at the stream's single position, flush it fully to disk, then swap it
+/// in through the same drain-and-reopen path a peer-snapshot restore uses. Returns
+/// the position the caller resumes the feed from.
+///
+/// Staging is what makes a mid-stream death safe. Applying into the live index and
+/// dying at 1% would leave a node claiming `position` with 1% of the data, resuming
+/// *after* it — and the missing 99% never arrives, because the feed only sends what
+/// is above `position`. A dead staging build is just a directory the next attempt
+/// deletes. The full flush matters for the same reason: the swap reopens from disk
+/// alone and discards the staging WAL, so anything not yet in a file segment would
+/// silently vanish from the installed index.
+pub fn bootstrapLineageFromSource(self: *Self, name: []const u8, generation: u64, stream: *BootstrapStream) !u64 {
+    const name_dir = try self.dir.openDir(name, .{ .iterate = true });
+    defer name_dir.close();
+    const redirect = index_redirect.read(name_dir, self.allocator) catch return error.IndexNotFound;
+    defer self.allocator.free(redirect.name);
+    if (redirect.deleted or redirect.generation != generation) return error.IndexGenerationMismatch;
+
+    var vbuf: [index_redirect.max_data_dir_len]u8 = undefined;
+    const vdir_name = redirect.dataDir(&vbuf);
+    const vdir = try name_dir.openDir(vdir_name, .{ .iterate = true });
+    defer vdir.close();
+
+    // 1. Build the staging index (outside the lock — this is the long part, and the
+    //    live index keeps serving searches meanwhile).
+    deleteDirTree(self.allocator, vdir, bootstrap_build_tmp) catch {}; // a prior attempt's corpse
+    var applied = false;
+    {
+        const build_dir = try openOrCreateDir(vdir, bootstrap_build_tmp);
+        errdefer deleteDirTree(self.allocator, vdir, bootstrap_build_tmp) catch {};
+
+        // sync=false: the stream's durability is the source's, and an interrupted
+        // build starts over either way. No start(): maintenance runs inline per
+        // batch, so no background coroutine races the final flush.
+        var staging = Index.open(self.allocator, build_dir, self.checkpoint_threshold, false, null) catch |err| {
+            build_dir.close();
+            return err;
+        };
+        defer staging.deinit(); // owns (and closes) build_dir
+
+        while (try stream.next()) |changes| {
+            if (changes.len == 0) continue;
+            _ = try staging.update(changes, .{ .version = stream.position });
+            try staging.runMaintenance();
+            applied = true;
+        }
+        if (applied) try staging.flush();
+    }
+
+    if (!applied) {
+        // The stream held nothing applicable, so there is nothing to install — and
+        // `position` is still the right place to resume: everything at or below it
+        // is, verifiably, nothing.
+        deleteDirTree(self.allocator, vdir, bootstrap_build_tmp) catch {};
+        return stream.position;
+    }
+
+    // 2. Move the staging data dir into the slot the snapshot restore uses, and
+    //    reuse its install path (block new borrows, drain, swap, reopen).
+    deleteDirTree(self.allocator, vdir, restore_tmp) catch {};
+    {
+        const build_dir = try vdir.openDir(bootstrap_build_tmp, .{ .iterate = true });
+        defer build_dir.close();
+        try build_dir.rename("data", vdir, restore_tmp);
+    }
+    deleteDirTree(self.allocator, vdir, bootstrap_build_tmp) catch {};
     return self.installBootstrap(name, generation, name_dir, vdir_name, vdir);
 }
 

--- a/src/MultiIndex.zig
+++ b/src/MultiIndex.zig
@@ -627,10 +627,24 @@ pub fn bootstrapLineageFromSource(self: *Self, name: []const u8, generation: u64
     const vdir = try name_dir.openDir(vdir_name, .{ .iterate = true });
     defer vdir.close();
 
+    // Whether anything needs installing is a property of the stream's CONTENT, never
+    // of its position. Position 0 with a full corpus is not an edge case, it is the
+    // primary migration scenario: the changelog goes live alongside an old corpus
+    // and may not have recorded anything yet when the first node arrives. Peek past
+    // empty batches before building anything, so the common fresh-lineage case (an
+    // empty stream) costs no disk at all.
+    const first_batch = blk: {
+        while (try stream.next()) |changes| {
+            if (changes.len > 0) break :blk changes;
+        }
+        break :blk null;
+    } orelse return stream.position;
+
+    log.info("bootstrapping '{s}' gen {d} from a source stream at position {d}", .{ name, generation, stream.position });
+
     // 1. Build the staging index (outside the lock — this is the long part, and the
     //    live index keeps serving searches meanwhile).
     deleteDirTree(self.allocator, vdir, bootstrap_build_tmp) catch {}; // a prior attempt's corpse
-    var applied = false;
     {
         const build_dir = try openOrCreateDir(vdir, bootstrap_build_tmp);
         errdefer deleteDirTree(self.allocator, vdir, bootstrap_build_tmp) catch {};
@@ -644,21 +658,14 @@ pub fn bootstrapLineageFromSource(self: *Self, name: []const u8, generation: u64
         };
         defer staging.deinit(); // owns (and closes) build_dir
 
+        _ = try staging.update(first_batch, .{ .version = stream.position });
+        try staging.runMaintenance();
         while (try stream.next()) |changes| {
             if (changes.len == 0) continue;
             _ = try staging.update(changes, .{ .version = stream.position });
             try staging.runMaintenance();
-            applied = true;
         }
-        if (applied) try staging.flush();
-    }
-
-    if (!applied) {
-        // The stream held nothing applicable, so there is nothing to install — and
-        // `position` is still the right place to resume: everything at or below it
-        // is, verifiably, nothing.
-        deleteDirTree(self.allocator, vdir, bootstrap_build_tmp) catch {};
-        return stream.position;
+        try staging.flush();
     }
 
     // 2. Move the staging data dir into the slot the snapshot restore uses, and

--- a/src/MultiIndex.zig
+++ b/src/MultiIndex.zig
@@ -601,8 +601,10 @@ const restore_tmp = "data.restore";
 /// returning the new version (the snapshot watermark). The ref — and thus the data
 /// consumer — survives; only the underlying Index is swapped, so the consumer resumes
 /// from the returned version. Called by the Replicator's consumer after a
-/// below-retention read.
-pub fn bootstrapLineage(self: *Self, name: []const u8, generation: u64, reader: *std.Io.Reader) !u64 {
+/// below-retention read. `transfer_deadline` is the caller's backstop on the
+/// transfer; it is disarmed the moment the snapshot is fully drained, so it can
+/// never abort the local swap (see disarmTransferDeadline).
+pub fn bootstrapLineage(self: *Self, name: []const u8, generation: u64, reader: *std.Io.Reader, transfer_deadline: ?*zio.AutoCancel) !u64 {
     var arena = std.heap.ArenaAllocator.init(self.allocator);
     defer arena.deinit();
     const a = arena.allocator();
@@ -627,11 +629,34 @@ pub fn bootstrapLineage(self: *Self, name: []const u8, generation: u64, reader: 
         try snapshot.restoreInto(restore_dir, reader, a, generation);
     }
 
+    // The snapshot is fully drained; the donor can no longer wedge us. Disarm the
+    // transfer backstop before the local swap, which must always run to completion.
+    try disarmTransferDeadline(transfer_deadline);
+
     // 2. Swap it in and reopen the index in place (under the lock, draining borrows).
     return self.installBootstrap(name, generation, name_dir, vdir_name, vdir);
 }
 
 const bootstrap_build_tmp = "bootstrap.tmp";
+
+// Disarm a bootstrap transfer deadline once the remote stream is fully drained.
+// The deadline exists to bound a wedged transfer; everything after the last byte is
+// bounded local work (flush, rename, drain-and-swap) whose interruption costs the
+// lineage — installBootstrap's failure path drops it from the map, and the consumer
+// then wedges on IndexNotFound. clear() alone is not enough: it only stops a timer
+// that has not fired yet, and one that fired in the instant before leaves a
+// cancellation already pending on this task, which would otherwise surface at the
+// install's first suspension point. checkCancel() surfaces it HERE, where it is
+// still harmless, and check() consumes it. A real cancellation (shutdown, delete)
+// propagates unchanged — user cancellation has priority in check().
+fn disarmTransferDeadline(transfer_deadline: ?*zio.AutoCancel) !void {
+    const d = transfer_deadline orelse return;
+    d.clear();
+    zio.checkCancel() catch |err| {
+        if (err == error.Canceled and d.check(error.Canceled)) return;
+        return err;
+    };
+}
 
 /// Bootstrap the (`name`, `generation`) lineage from the feed's own corpus stream
 /// (Coordinator.openBootstrap): build a staging index next to the live one, apply
@@ -646,7 +671,12 @@ const bootstrap_build_tmp = "bootstrap.tmp";
 /// deletes. The full flush matters for the same reason: the swap reopens from disk
 /// alone and discards the staging WAL, so anything not yet in a file segment would
 /// silently vanish from the installed index.
-pub fn bootstrapLineageFromSource(self: *Self, name: []const u8, generation: u64, stream: *BootstrapStream) !u64 {
+///
+/// `transfer_deadline` is the caller's backstop on the stream; it is disarmed the
+/// moment the stream is fully drained, so a slow-but-successful transfer can never
+/// have its result destroyed by the timer firing into the flush or the swap (see
+/// disarmTransferDeadline).
+pub fn bootstrapLineageFromSource(self: *Self, name: []const u8, generation: u64, stream: *BootstrapStream, transfer_deadline: ?*zio.AutoCancel) !u64 {
     const name_dir = try self.dir.openDir(name, .{ .iterate = true });
     defer name_dir.close();
     const redirect = index_redirect.read(name_dir, self.allocator) catch return error.IndexNotFound;
@@ -669,7 +699,10 @@ pub fn bootstrapLineageFromSource(self: *Self, name: []const u8, generation: u64
             if (changes.len > 0) break :blk changes;
         }
         break :blk null;
-    } orelse return stream.position;
+    } orelse {
+        try disarmTransferDeadline(transfer_deadline); // drained: nothing to install
+        return stream.position;
+    };
 
     log.info("bootstrapping '{s}' gen {d} from a source stream at position {d}", .{ name, generation, stream.position });
 
@@ -696,6 +729,12 @@ pub fn bootstrapLineageFromSource(self: *Self, name: []const u8, generation: u64
             _ = try staging.update(changes, .{ .version = stream.position });
             try staging.runMaintenance();
         }
+
+        // The stream is fully drained; the source can no longer wedge us. Disarm
+        // the transfer backstop before the flush and the swap, which must always
+        // run to completion once the data has arrived.
+        try disarmTransferDeadline(transfer_deadline);
+
         try staging.flush();
     }
 

--- a/src/MultiIndex.zig
+++ b/src/MultiIndex.zig
@@ -287,6 +287,16 @@ fn openOneIndexInner(self: *Self, name: []const u8, load_sem: ?*zio.Semaphore, o
 pub fn search(self: *Self, arena: std.mem.Allocator, name: []const u8, request: api.SearchRequest) !api.SearchResponse {
     const index = try self.getIndex(name);
     defer self.releaseIndex(index);
+
+    // While a bootstrap fills this index (initial seed or below-retention
+    // restore), refuse rather than answer: every result would be an
+    // honest-looking but empty or stale set. IndexNotReady -> 503, the same
+    // signal the health probe gives, so a caller that skipped the probe still
+    // cannot mistake a loading node for a miss. After getIndex, so a missing
+    // index keeps answering 404 rather than 503.
+    if (self.replication) |repl| {
+        if (repl.isBootstrapping(name)) return error.IndexNotReady;
+    }
     metrics.incSearches();
 
     const collector = try self.results_pool.acquire(.{
@@ -399,6 +409,27 @@ pub fn checkIndexExists(self: *Self, name: []const u8) !bool {
     defer self.lock.unlock();
     const ref = self.indexes.get(name) orelse return false;
     return !ref.being_deleted;
+}
+
+pub const IndexHealth = enum { ready, loading, missing };
+
+/// Per-index health: `loading` while the index exists but its consumer is filling
+/// it by bootstrap — the initial empty-lineage seed or a below-retention restore.
+/// Either way its answers would be honest-looking but empty or stale, so a search
+/// balancer must be able to tell. Global liveness (/_health) deliberately stays
+/// independent of this: peer discovery must keep finding nodes that are
+/// open-but-loading, or a cold cluster start deadlocks (see
+/// notes/bootstrap-design.md).
+pub fn indexHealth(self: *Self, name: []const u8) !IndexHealth {
+    try self.lock.lock();
+    defer self.lock.unlock();
+    const ref = self.indexes.get(name) orelse return .missing;
+    if (ref.being_deleted) return .missing;
+    // Same lock order as the reconcile paths: MultiIndex.lock -> Replicator.mutex.
+    if (self.replication) |repl| {
+        if (repl.isBootstrapping(name)) return .loading;
+    }
+    return .ready;
 }
 
 /// Snapshot of the current local index names (owned: caller frees each string and

--- a/src/RemoteCoordinator.zig
+++ b/src/RemoteCoordinator.zig
@@ -68,6 +68,7 @@ const vtable: Coordinator.VTable = .{
     .deleteIndex = deleteIndexImpl,
     .readMeta = readMetaImpl,
     .setRetentionFloor = setRetentionFloorImpl,
+    .openBootstrap = openBootstrapImpl,
 };
 
 fn appendImpl(ptr: *anyopaque, index_name: []const u8, generation: u64, changes: []const Change, expected: ?u64) anyerror!u64 {
@@ -265,6 +266,80 @@ fn arenaFor(self: *Self, index_name: []const u8) !*std.heap.ArenaAllocator {
     return gop.value_ptr.*;
 }
 
+// ---- bootstrap (a node that has nothing) ----
+//
+// GET /_bootstrap/{index}/{generation} answers with one msgpack BootstrapHeader,
+// then arrays of Change decoded straight off the socket (msgpack values are
+// self-delimiting), terminated by an empty array. The terminator carries the
+// done-versus-died distinction: end-of-stream without it means the server died
+// mid-scan, and surfaces as the decode error rather than as a shorter corpus.
+
+const BootstrapCtx = struct {
+    allocator: std.mem.Allocator,
+    client: http.Client,
+    resp: http.ClientResponse,
+    arena: std.heap.ArenaAllocator,
+    done: bool = false,
+
+    const stream_vtable: changelog_mod.BootstrapStream.VTable = .{
+        .next = nextImpl,
+        .deinit = deinitImpl,
+    };
+
+    fn nextImpl(ptr: *anyopaque) anyerror!?[]const Change {
+        const self: *BootstrapCtx = @ptrCast(@alignCast(ptr));
+        if (self.done) return null;
+        _ = self.arena.reset(.retain_capacity); // frees the previous batch
+        const batch = try nextBatch(self.arena.allocator(), self.resp.reader());
+        if (batch == null) self.done = true;
+        return batch;
+    }
+
+    fn deinitImpl(ptr: *anyopaque) void {
+        const self: *BootstrapCtx = @ptrCast(@alignCast(ptr));
+        const allocator = self.allocator;
+        self.arena.deinit();
+        self.resp.deinit();
+        self.client.deinit();
+        allocator.destroy(self);
+    }
+};
+
+// One msgpack array per call. Null is ONLY the empty-array terminator; a stream
+// that just stops errors out of the decode instead, so truncation can never read
+// as completion.
+fn nextBatch(arena: std.mem.Allocator, r: *std.Io.Reader) anyerror!?[]Change {
+    const changes = try msgpack.decodeLeaky([]Change, arena, r);
+    if (changes.len == 0) return null;
+    return changes;
+}
+
+fn openBootstrapImpl(ptr: *anyopaque, index_name: []const u8, generation: u64) anyerror!changelog_mod.BootstrapStream {
+    const self: *Self = @ptrCast(@alignCast(ptr));
+
+    var url_buf: [max_url_len]u8 = undefined;
+    const url = try std.fmt.bufPrint(&url_buf, "{s}/_bootstrap/{s}/{d}", .{ self.base_url, index_name, generation });
+
+    const ctx = try self.allocator.create(BootstrapCtx);
+    errdefer self.allocator.destroy(ctx);
+    ctx.* = .{
+        .allocator = self.allocator,
+        .client = http.Client.init(self.allocator, self.io, .{}),
+        .resp = undefined,
+        .arena = std.heap.ArenaAllocator.init(self.allocator),
+    };
+    errdefer ctx.arena.deinit();
+    errdefer ctx.client.deinit();
+    ctx.resp = try ctx.client.fetch(url, .{ .method = .get });
+    errdefer ctx.resp.deinit();
+    if (ctx.resp.status() != .ok) return statusToError(ctx.resp.status());
+
+    // The reader points into ctx.resp, so it is only taken now that ctx sits at
+    // its final heap address.
+    const header = try msgpack.decodeLeaky(changelog_mod.BootstrapHeader, ctx.arena.allocator(), ctx.resp.reader());
+    return .{ .ptr = ctx, .vtable = &BootstrapCtx.stream_vtable, .position = header.position };
+}
+
 fn statusToError(status: http.Status) anyerror {
     return switch (status) {
         .conflict => error.VersionMismatch,
@@ -323,4 +398,53 @@ test "statusToError: 403 is a permanent refusal, not a retryable outage" {
     // caller to try again later for something that can never succeed.
     try std.testing.expectEqual(error.FeedIsReadOnly, statusToError(.forbidden));
     try std.testing.expect(statusToError(.forbidden) != error.CoordinatorError);
+}
+
+// The bootstrap wire format, pinned against hand-written bytes rather than a
+// round-trip through our own encoder — a round-trip would pass just as happily if
+// every key were wrong. These are the exact bytes the Python feed emits
+// (acoustid-server, tests/future/fpindex/test_feed.py pins its half the same way).
+
+test "bootstrap wire: header, one array of changes, empty-array terminator" {
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+    const a = arena.allocator();
+
+    const bytes = [_]u8{
+        0x81, 0xa1, 'p', 0x03, // header {"p": 3}
+        0x91, // array of 1 change:
+        0x81, 0xa1, 'i', // tagged union: {"i": Insert}
+        0x82, 0xa1, 'i', 0x2a, // {"i": 42,
+        0xa1, 'h', 0x93, 0x01, 0x02, 0x03, //  "h": [1, 2, 3]}
+        0x90, // terminator: empty array
+    };
+    var r = std.Io.Reader.fixed(&bytes);
+
+    const header = try msgpack.decodeLeaky(changelog_mod.BootstrapHeader, a, &r);
+    try std.testing.expectEqual(@as(u64, 3), header.position);
+
+    const batch = (try nextBatch(a, &r)).?;
+    try std.testing.expectEqual(@as(usize, 1), batch.len);
+    try std.testing.expectEqual(@as(u32, 42), batch[0].insert.id);
+    try std.testing.expectEqualSlices(u32, &.{ 1, 2, 3 }, batch[0].insert.hashes);
+
+    try std.testing.expectEqual(@as(?[]Change, null), try nextBatch(a, &r));
+}
+
+test "bootstrap wire: a stream that stops without the terminator is an error, not a shorter corpus" {
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+    const a = arena.allocator();
+
+    // One full batch, then the connection dies: no 0x90.
+    const bytes = [_]u8{
+        0x91, 0x81, 0xa1, 'i', 0x82, 0xa1, 'i', 0x2a, 0xa1, 'h', 0x91, 0x07,
+    };
+    var r = std.Io.Reader.fixed(&bytes);
+
+    _ = (try nextBatch(a, &r)).?;
+    // Installing what arrived so far as "complete" is the one unrecoverable
+    // mistake here — the node would claim the stream's position while missing
+    // whatever never arrived, and the feed would never send it again.
+    try std.testing.expectError(error.EndOfStream, nextBatch(a, &r));
 }

--- a/src/Replicator.zig
+++ b/src/Replicator.zig
@@ -331,9 +331,10 @@ fn trySeed(self: *Self, c: *Consumer) !u64 {
     var stream = (self.coordinator.openBootstrap(c.name, c.generation) catch |err|
         return seedTimeoutOr(&deadline, err)) orelse return 0;
     defer stream.deinit();
-    if (stream.position == 0) return 0; // nothing exists before the log; replay is right
 
-    log.info("bootstrapping '{s}' gen {d} from the source stream (position {d})", .{ c.name, c.generation, stream.position });
+    // No position-0 shortcut here: a young changelog legitimately reports 0 while
+    // the stream carries the whole pre-migration corpus. Whether there is anything
+    // to install is decided by the stream's content, inside the build.
     return self.mi.bootstrapLineageFromSource(c.name, c.generation, &stream) catch |err|
         seedTimeoutOr(&deadline, err);
 }
@@ -905,6 +906,53 @@ test "bootstrapLineageFromSource builds, flushes and swaps in a corpus stream" {
     const st = try mi.getPeerStatus("main");
     try std.testing.expectEqual(@as(u64, 42), st.version);
     try std.testing.expectEqual(@as(u64, 42), st.file_version);
+}
+
+test "a corpus streamed at position 0 still installs — the primary migration case" {
+    const common = @import("common.zig");
+    const BootstrapStream = coordinator_mod.BootstrapStream;
+
+    const rt = try zio.Runtime.init(std.testing.allocator, .{});
+    defer rt.deinit();
+
+    const cwd = zio.Dir.cwd();
+    const dir_path = "test_bootstrap_source_pos0";
+    common.deleteDirTree(std.testing.allocator, cwd, dir_path) catch {};
+    try cwd.createDir(dir_path, 0o755);
+    defer common.deleteDirTree(std.testing.allocator, cwd, dir_path) catch {};
+    const dir = try cwd.openDir(dir_path, .{ .iterate = true });
+
+    var mi = MultiIndex.init(std.testing.allocator, dir);
+    defer mi.deinit();
+    _ = try mi.createIndex("main", .{ .generation = 1 });
+
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+    const a = arena.allocator();
+
+    // A changelog that went live next to an old corpus and has recorded nothing
+    // yet reports position 0 WITH a full stream. Skipping it on the position
+    // would replay from 0 and silently miss the entire corpus.
+    const Fake = struct {
+        served: bool = false,
+        const vt: BootstrapStream.VTable = .{ .next = nextImpl, .deinit = deinitImpl };
+        fn nextImpl(ptr: *anyopaque) anyerror!?[]const Change {
+            const self: *@This() = @ptrCast(@alignCast(ptr));
+            if (self.served) return null;
+            self.served = true;
+            return &.{.{ .insert = .{ .id = 7, .hashes = &.{ 7, 8, 9 } } }};
+        }
+        fn deinitImpl(_: *anyopaque) void {}
+    };
+    var fake = Fake{};
+    var stream = BootstrapStream{ .ptr = &fake, .vtable = &Fake.vt, .position = 0 };
+
+    try std.testing.expectEqual(@as(u64, 0), try mi.bootstrapLineageFromSource("main", 1, &stream));
+
+    var q = [_]u32{ 7, 8, 9 };
+    const hit = try mi.search(a, "main", .{ .query = &q });
+    try std.testing.expectEqual(@as(usize, 1), hit.results.len);
+    try std.testing.expectEqual(@as(u32, 7), hit.results[0].id);
 }
 
 test "an empty node below a truncated log seeds from the source stream" {

--- a/src/Replicator.zig
+++ b/src/Replicator.zig
@@ -344,7 +344,10 @@ fn trySeed(self: *Self, c: *Consumer) !u64 {
 
     // Same backstop as a snapshot transfer: a source that accepts the connection
     // and then wedges must not hang the consumer forever. Raise
-    // --bootstrap-timeout-ms for corpora that legitimately stream longer.
+    // --bootstrap-timeout-ms for corpora that legitimately stream longer. It bounds
+    // only the stream: bootstrapLineageFromSource disarms it the moment the stream
+    // is drained, so the timer cannot fire into the install and destroy the
+    // lineage a slow-but-successful transfer just delivered.
     var deadline: zio.AutoCancel = .init;
     defer deadline.clear();
     deadline.set(.{ .duration = self.bootstrap_timeout });
@@ -356,7 +359,7 @@ fn trySeed(self: *Self, c: *Consumer) !u64 {
     // No position-0 shortcut here: a young changelog legitimately reports 0 while
     // the stream carries the whole pre-migration corpus. Whether there is anything
     // to install is decided by the stream's content, inside the build.
-    return self.mi.bootstrapLineageFromSource(c.name, c.generation, &stream) catch |err|
+    return self.mi.bootstrapLineageFromSource(c.name, c.generation, &stream, &deadline) catch |err|
         seedTimeoutOr(&deadline, err);
 }
 
@@ -374,7 +377,7 @@ fn fetchFrom(self: *Self, arena: std.mem.Allocator, c: *Consumer, donor: peers_m
     defer deadline.clear();
     deadline.set(.{ .duration = self.bootstrap_timeout });
 
-    return self.fetchFromInner(arena, c, donor) catch |err| {
+    return self.fetchFromInner(arena, c, donor, &deadline) catch |err| {
         // Our own deadline, not a shutdown: report it as a donor failure so the caller
         // moves on to the next candidate. A real cancel must stay error.Canceled and
         // unwind the consumer.
@@ -386,7 +389,7 @@ fn fetchFrom(self: *Self, arena: std.mem.Allocator, c: *Consumer, donor: peers_m
     };
 }
 
-fn fetchFromInner(self: *Self, arena: std.mem.Allocator, c: *Consumer, donor: peers_mod.Donor) !u64 {
+fn fetchFromInner(self: *Self, arena: std.mem.Allocator, c: *Consumer, donor: peers_mod.Donor, deadline: *zio.AutoCancel) !u64 {
     const url = try std.fmt.allocPrint(arena, "{s}/{s}/_snapshot", .{ donor.base_url, c.name });
 
     // A client per fetch: dusty's connection pool has no locking, and two indexes can
@@ -399,7 +402,7 @@ fn fetchFromInner(self: *Self, arena: std.mem.Allocator, c: *Consumer, donor: pe
     if (resp.status() != .ok) return error.SnapshotFetchFailed;
 
     log.info("bootstrapping '{s}' gen {d} from {s} (watermark {d})", .{ c.name, c.generation, donor.base_url, donor.file_version });
-    return self.mi.bootstrapLineage(c.name, c.generation, resp.reader());
+    return self.mi.bootstrapLineage(c.name, c.generation, resp.reader(), deadline);
 }
 
 fn consumeLoop(c: *Consumer, start_version: u64) zio.Cancelable!void {
@@ -866,7 +869,7 @@ test "bootstrapLineage swaps an index's data from a donor snapshot" {
     // Bootstrap main from the donor snapshot: it now serves the donor's data at the
     // donor's version, and the old doc is gone.
     var r = std.Io.Reader.fixed(buf.written());
-    try std.testing.expectEqual(donor_version, try mi.bootstrapLineage("main", 1, &r));
+    try std.testing.expectEqual(donor_version, try mi.bootstrapLineage("main", 1, &r, null));
 
     var q99 = [_]u32{ 7, 8, 9 };
     const hit = try mi.search(a, "main", .{ .query = &q99 });
@@ -920,7 +923,7 @@ test "bootstrapLineageFromSource builds, flushes and swaps in a corpus stream" {
     } };
     var stream = BootstrapStream{ .ptr = &fake, .vtable = &Fake.vt, .position = 42 };
 
-    try std.testing.expectEqual(@as(u64, 42), try mi.bootstrapLineageFromSource("main", 1, &stream));
+    try std.testing.expectEqual(@as(u64, 42), try mi.bootstrapLineageFromSource("main", 1, &stream, null));
 
     // The streamed corpus is searchable; the pre-existing doc is gone with the swap.
     var q = [_]u32{ 7, 8, 9 };
@@ -977,10 +980,65 @@ test "a corpus streamed at position 0 still installs — the primary migration c
     var fake = Fake{};
     var stream = BootstrapStream{ .ptr = &fake, .vtable = &Fake.vt, .position = 0 };
 
-    try std.testing.expectEqual(@as(u64, 0), try mi.bootstrapLineageFromSource("main", 1, &stream));
+    try std.testing.expectEqual(@as(u64, 0), try mi.bootstrapLineageFromSource("main", 1, &stream, null));
 
     var q = [_]u32{ 7, 8, 9 };
     const hit = try mi.search(a, "main", .{ .query = &q });
+    try std.testing.expectEqual(@as(usize, 1), hit.results.len);
+    try std.testing.expectEqual(@as(u32, 7), hit.results[0].id);
+}
+
+test "a transfer deadline firing as the stream drains cannot destroy the install" {
+    const common = @import("common.zig");
+    const BootstrapStream = coordinator_mod.BootstrapStream;
+
+    const rt = try zio.Runtime.init(std.testing.allocator, .{});
+    defer rt.deinit();
+
+    const cwd = zio.Dir.cwd();
+    const dir_path = "test_bootstrap_deadline_install";
+    common.deleteDirTree(std.testing.allocator, cwd, dir_path) catch {};
+    try cwd.createDir(dir_path, 0o755);
+    defer common.deleteDirTree(std.testing.allocator, cwd, dir_path) catch {};
+    const dir = try cwd.openDir(dir_path, .{ .iterate = true });
+
+    var mi = MultiIndex.init(std.testing.allocator, dir);
+    defer mi.deinit();
+    _ = try mi.createIndex("main", .{ .generation = 1 });
+
+    var deadline: zio.AutoCancel = .init;
+    defer deadline.clear();
+
+    // Serves one batch, then arms the deadline to fire IMMEDIATELY while returning
+    // the terminator — the worst-case timing: the transfer just made it under the
+    // wire, and the timer would land inside the flush or the swap. That used to
+    // abort the install mid-way (dropping the whole lineage from the map); the
+    // deadline must instead be dead the moment the stream is drained.
+    const Fake = struct {
+        deadline: *zio.AutoCancel,
+        served: bool = false,
+        const vt: BootstrapStream.VTable = .{ .next = nextImpl, .deinit = deinitImpl };
+        fn nextImpl(ptr: *anyopaque) anyerror!?[]const Change {
+            const self: *@This() = @ptrCast(@alignCast(ptr));
+            if (!self.served) {
+                self.served = true;
+                return &.{.{ .insert = .{ .id = 7, .hashes = &.{ 7, 8, 9 } } }};
+            }
+            self.deadline.set(.{ .duration = .fromMilliseconds(0) });
+            return null;
+        }
+        fn deinitImpl(_: *anyopaque) void {}
+    };
+    var fake = Fake{ .deadline = &deadline };
+    var stream = BootstrapStream{ .ptr = &fake, .vtable = &Fake.vt, .position = 5 };
+
+    // Slow-but-successful must still install, not be destroyed at the finish line.
+    try std.testing.expectEqual(@as(u64, 5), try mi.bootstrapLineageFromSource("main", 1, &stream, &deadline));
+
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+    var q = [_]u32{ 7, 8, 9 };
+    const hit = try mi.search(arena.allocator(), "main", .{ .query = &q });
     try std.testing.expectEqual(@as(usize, 1), hit.results.len);
     try std.testing.expectEqual(@as(u32, 7), hit.results[0].id);
 }

--- a/src/Replicator.zig
+++ b/src/Replicator.zig
@@ -91,6 +91,11 @@ const Consumer = struct {
     generation: u64, // the lineage this consumer follows
     replicator: *Self,
     applied: u64, // max applied per-lineage seq (guarded by mutex)
+    // True while the consumer fills the index by bootstrap instead of the feed —
+    // the initial empty-lineage seed and a below-retention restore alike (guarded
+    // by mutex). Surfaced through per-index health so a search balancer keeps
+    // traffic off answers that would be honest-looking but empty or stale.
+    bootstrapping: bool = false,
     task: ?zio.JoinHandle(zio.Cancelable!void) = null,
 };
 
@@ -217,6 +222,22 @@ fn markApplied(self: *Self, c: *Consumer, version: u64) void {
     defer self.mutex.unlock();
     c.applied = version;
     self.cond.broadcast();
+}
+
+fn setBootstrapping(self: *Self, c: *Consumer, value: bool) void {
+    self.mutex.lockUncancelable();
+    defer self.mutex.unlock();
+    c.bootstrapping = value;
+}
+
+/// Whether `name`'s consumer is currently filling the index by bootstrap (initial
+/// seed or below-retention restore). False for an unknown name — absence is
+/// reported by the index lookup, not here.
+pub fn isBootstrapping(self: *Self, name: []const u8) bool {
+    self.mutex.lockUncancelable();
+    defer self.mutex.unlock();
+    const c = self.consumers.get(name) orelse return false;
+    return c.bootstrapping;
 }
 
 // Fetch a snapshot of (c.name, c.generation) from a peer and swap it into the local
@@ -386,7 +407,11 @@ fn consumeLoop(c: *Consumer, start_version: u64) zio.Cancelable!void {
     var buf: [batch_size]Entry = undefined;
     var changes: [batch_size]Change = undefined;
     var after = start_version;
-    if (after == 0) after = try self.seedEmptyLineage(c);
+    if (after == 0) after = blk: {
+        self.setBootstrapping(c, true);
+        defer self.setBootstrapping(c, false);
+        break :blk try self.seedEmptyLineage(c);
+    };
     while (true) {
         const n = self.coordinator.read(c.name, c.generation, after, &buf, .none) catch |err| {
             if (err == error.Canceled) return error.Canceled;
@@ -394,12 +419,17 @@ fn consumeLoop(c: *Consumer, start_version: u64) zio.Cancelable!void {
             // swap it in, and resume from its watermark. Retry on any bootstrap failure
             // (no donor yet, coordinator hiccup) — the next read re-signals.
             if (err == error.BelowRetention) {
+                // Below retention means the data is stale beyond what the feed can
+                // repair, so health reads loading for the WHOLE restore — sticky
+                // across failed attempts; the gap between retries must not flash OK.
+                self.setBootstrapping(c, true);
                 const f = self.bootstrapConsumer(c, after) catch |berr| {
                     if (berr == error.Canceled) return error.Canceled;
                     log.warn("bootstrap failed for '{s}' gen {d}: {}", .{ c.name, c.generation, berr });
                     try zio.sleep(read_retry);
                     continue;
                 };
+                self.setBootstrapping(c, false);
                 after = f;
                 self.markApplied(c, f);
                 continue;
@@ -1016,6 +1046,152 @@ test "an empty node below a truncated log seeds from the source stream" {
     const s3 = try mi.search(a, "main", .{ .query = &q3 });
     try std.testing.expectEqual(@as(usize, 1), s3.results.len);
     try std.testing.expectEqual(@as(u32, 3), s3.results[0].id);
+
+    // The seed is over, so per-index health is back to ready.
+    try std.testing.expectEqual(MultiIndex.IndexHealth.ready, try mi.indexHealth("main"));
+}
+
+// Delegates everything except openBootstrap, which always fails — a feed that
+// declares bootstrap but cannot serve it, freezing an empty consumer in its seed
+// retry loop.
+const StuckBootstrap = struct {
+    inner: Coordinator,
+
+    fn coordinator(self: *StuckBootstrap) Coordinator {
+        return .{ .ptr = self, .vtable = &vtable };
+    }
+    const vtable: Coordinator.VTable = .{
+        .append = appendImpl,
+        .read = readImpl,
+        .createIndex = createIndexImpl,
+        .deleteIndex = deleteIndexImpl,
+        .readMeta = readMetaImpl,
+        .setRetentionFloor = setRetentionFloorImpl,
+        .openBootstrap = openBootstrapImpl,
+    };
+    fn appendImpl(ptr: *anyopaque, name: []const u8, generation: u64, changes: []const Change, expected: ?u64) anyerror!u64 {
+        const self: *StuckBootstrap = @ptrCast(@alignCast(ptr));
+        return self.inner.append(name, generation, changes, expected);
+    }
+    fn readImpl(ptr: *anyopaque, name: []const u8, generation: u64, after: u64, out: []Entry, deadline: zio.Timeout) anyerror!usize {
+        const self: *StuckBootstrap = @ptrCast(@alignCast(ptr));
+        return self.inner.read(name, generation, after, out, deadline);
+    }
+    fn createIndexImpl(ptr: *anyopaque, name: []const u8) anyerror!u64 {
+        const self: *StuckBootstrap = @ptrCast(@alignCast(ptr));
+        return self.inner.createIndex(name);
+    }
+    fn deleteIndexImpl(ptr: *anyopaque, name: []const u8) anyerror!u64 {
+        const self: *StuckBootstrap = @ptrCast(@alignCast(ptr));
+        return self.inner.deleteIndex(name);
+    }
+    fn readMetaImpl(ptr: *anyopaque, after: u64, out: []MetaOp, deadline: zio.Timeout) anyerror!usize {
+        const self: *StuckBootstrap = @ptrCast(@alignCast(ptr));
+        return self.inner.readMeta(after, out, deadline);
+    }
+    fn setRetentionFloorImpl(ptr: *anyopaque, name: []const u8, generation: u64, floor: u64) anyerror!void {
+        const self: *StuckBootstrap = @ptrCast(@alignCast(ptr));
+        return self.inner.setRetentionFloor(name, generation, floor);
+    }
+    fn openBootstrapImpl(_: *anyopaque, _: []const u8, _: u64) anyerror!coordinator_mod.BootstrapStream {
+        return error.CoordinatorError;
+    }
+};
+
+test "per-index health reads loading while the initial seed cannot complete" {
+    const MemoryCoordinator = coordinator_mod.MemoryCoordinator;
+    const common = @import("common.zig");
+
+    const rt = try zio.Runtime.init(std.testing.allocator, .{ .executors = .exact(2) });
+    defer rt.deinit();
+
+    const cwd = zio.Dir.cwd();
+    const dir_path = "test_replicator_health_loading";
+    common.deleteDirTree(std.testing.allocator, cwd, dir_path) catch {};
+    try cwd.createDir(dir_path, 0o755);
+    defer common.deleteDirTree(std.testing.allocator, cwd, dir_path) catch {};
+    const dir = try cwd.openDir(dir_path, .{ .iterate = true });
+
+    var cl = MemoryCoordinator.init(std.testing.allocator);
+    defer cl.deinit();
+    const gen = try cl.coordinator().createIndex("main");
+    _ = try cl.coordinator().append("main", gen, &[_]Change{.{ .insert = .{ .id = 1, .hashes = &.{ 1, 2, 3 } } }}, null);
+    try cl.setRetentionFloor("main", gen, 1); // replay from 0 impossible; only a bootstrap can seed
+
+    var stuck = StuckBootstrap{ .inner = cl.coordinator() };
+    var mi = MultiIndex.init(std.testing.allocator, dir);
+    defer mi.deinit();
+    try mi.startReplication(stuck.coordinator());
+
+    // The index reconciles into existence and its consumer parks in the seed retry
+    // loop. Health must say loading — the bare exists-check would say OK, and a
+    // search balancer would route queries to a node that answers all of them with
+    // an honest-looking empty result.
+    var i: usize = 0;
+    const loading = while (i < 300) : (i += 1) {
+        if ((try mi.indexHealth("main")) == .loading) break true;
+        try zio.sleep(.fromMilliseconds(10));
+    } else false;
+    try std.testing.expect(loading);
+
+    // Searches are refused outright while loading, not answered empty.
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+    var q = [_]u32{ 1, 2, 3 };
+    try std.testing.expectError(error.IndexNotReady, mi.search(arena.allocator(), "main", .{ .query = &q }));
+
+    try std.testing.expectEqual(MultiIndex.IndexHealth.missing, try mi.indexHealth("nope"));
+}
+
+test "per-index health reads loading during a below-retention restore too" {
+    const MemoryCoordinator = coordinator_mod.MemoryCoordinator;
+    const common = @import("common.zig");
+
+    const rt = try zio.Runtime.init(std.testing.allocator, .{ .executors = .exact(2) });
+    defer rt.deinit();
+
+    const cwd = zio.Dir.cwd();
+    const dir_path = "test_replicator_health_restore";
+    common.deleteDirTree(std.testing.allocator, cwd, dir_path) catch {};
+    try cwd.createDir(dir_path, 0o755);
+    defer common.deleteDirTree(std.testing.allocator, cwd, dir_path) catch {};
+    const dir = try cwd.openDir(dir_path, .{ .iterate = true });
+
+    var cl = MemoryCoordinator.init(std.testing.allocator);
+    defer cl.deinit();
+    const co = cl.coordinator();
+
+    var mi = MultiIndex.init(std.testing.allocator, dir);
+    defer mi.deinit();
+    try mi.startReplication(co);
+
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+    const a = arena.allocator();
+
+    const created = try mi.createIndex("main", .{});
+    _ = try mi.update(a, "main", .{ .changes = &[_]Change{.{ .insert = .{ .id = 1, .hashes = &.{ 10, 20 } } }} });
+    try std.testing.expectEqual(MultiIndex.IndexHealth.ready, try mi.indexHealth("main"));
+
+    // Move the floor far past everything, then wake the parked read with one more
+    // append (which it still returns — the floor is checked on entry). The NEXT
+    // read lands below retention, and with no peers configured the restore can
+    // never complete: the consumer parks in the retry loop.
+    try co.setRetentionFloor("main", created.generation, 10);
+    _ = try co.append("main", created.generation, &[_]Change{.{ .insert = .{ .id = 2, .hashes = &.{ 30, 40 } } }}, null);
+
+    var i: usize = 0;
+    const loading = while (i < 300) : (i += 1) {
+        if ((try mi.indexHealth("main")) == .loading) break true;
+        try zio.sleep(.fromMilliseconds(10));
+    } else false;
+    try std.testing.expect(loading);
+
+    // The stale data must not serve while the restore is pending: a result set
+    // from below the retention floor is honest-looking and wrong. 503, not 404 —
+    // the index exists, it just cannot answer yet.
+    var q = [_]u32{ 10, 20 };
+    try std.testing.expectError(error.IndexNotReady, mi.search(a, "main", .{ .query = &q }));
 }
 
 test "meta consumer drops a local index absent from the meta feed" {
@@ -1393,6 +1569,15 @@ test "replicated delete+recreate converges on the new lineage" {
     _ = try mi.deleteIndex("main", .{});
     const c2 = try mi.createIndex("main", .{});
     try std.testing.expect(c2.generation > c1.generation);
+
+    // The new lineage's consumer runs its (empty) seed first, and searches are
+    // refused until it has decided there is nothing to load — so wait for ready
+    // rather than race it.
+    var i: usize = 0;
+    while (i < 300) : (i += 1) {
+        if ((try mi.indexHealth("main")) == .ready) break;
+        try zio.sleep(.fromMilliseconds(10));
+    }
 
     // The recreated index is empty — the old lineage's doc is gone (isolation is
     // the generation scope).

--- a/src/Replicator.zig
+++ b/src/Replicator.zig
@@ -279,6 +279,72 @@ fn canResumeFrom(self: *Self, c: *Consumer, file_version: u64) !bool {
     return true;
 }
 
+// An empty index must not replay a feed whose history starts later than its corpus:
+// the PG changelog begins at the migration, so a replay from 0 builds an index that
+// is silently missing every fingerprint older than the log — while being told
+// "caught up". Whether that hazard exists is the feed's own declaration:
+// openBootstrap is non-null exactly when history is incomplete from 0.
+//
+// Preference order:
+//   1. a peer snapshot — the corpus already built and inside the cluster is far
+//      cheaper than pulling a terabyte back out of the source database,
+//   2. the feed's bootstrap stream — one node pays this once per cluster, and the
+//      rest then find that node as a donor,
+//   3. plain replay from 0 — feeds with complete history (the file log, the memory
+//      coordinator before truncation) neither need nor offer the stream.
+//
+// Deliberately NOT wired into the below-retention path: a whole cluster falling off
+// the log at once would stampede the source with N corpus streams. That remedy stays
+// operator-driven — wipe one node, which makes it empty and lands it here.
+fn seedEmptyLineage(self: *Self, c: *Consumer) zio.Cancelable!u64 {
+    while (true) {
+        if (self.trySeed(c)) |position| {
+            if (position > 0) self.markApplied(c, position);
+            return position;
+        } else |err| {
+            if (err == error.Canceled) return error.Canceled;
+            log.warn("seeding empty lineage '{s}' gen {d} failed (retrying): {}", .{ c.name, c.generation, err });
+            try zio.sleep(read_retry);
+        }
+    }
+}
+
+fn trySeed(self: *Self, c: *Consumer) !u64 {
+    if (self.bootstrapConsumer(c, 0)) |v| {
+        return v;
+    } else |err| switch (err) {
+        error.Canceled => return error.Canceled,
+        // No peer can help; that is exactly what the source stream is for.
+        error.NoPeersConfigured, error.NoDonor, error.AllDonorsBelowRetention => {},
+        // A donor exists but its transfer failed — retrying peers is far cheaper
+        // than a corpus stream, so let the seed loop come back around.
+        else => |e| return e,
+    }
+
+    // Same backstop as a snapshot transfer: a source that accepts the connection
+    // and then wedges must not hang the consumer forever. Raise
+    // --bootstrap-timeout-ms for corpora that legitimately stream longer.
+    var deadline: zio.AutoCancel = .init;
+    defer deadline.clear();
+    deadline.set(.{ .duration = self.bootstrap_timeout });
+
+    var stream = (self.coordinator.openBootstrap(c.name, c.generation) catch |err|
+        return seedTimeoutOr(&deadline, err)) orelse return 0;
+    defer stream.deinit();
+    if (stream.position == 0) return 0; // nothing exists before the log; replay is right
+
+    log.info("bootstrapping '{s}' gen {d} from the source stream (position {d})", .{ c.name, c.generation, stream.position });
+    return self.mi.bootstrapLineageFromSource(c.name, c.generation, &stream) catch |err|
+        seedTimeoutOr(&deadline, err);
+}
+
+// Our own transfer deadline, not a shutdown: report it as a seed failure so the
+// loop retries. A real cancel must stay error.Canceled and unwind the consumer.
+fn seedTimeoutOr(deadline: *zio.AutoCancel, err: anyerror) anyerror {
+    if (err == error.Canceled and deadline.check(error.Canceled)) return error.BootstrapTimeout;
+    return err;
+}
+
 fn fetchFrom(self: *Self, arena: std.mem.Allocator, c: *Consumer, donor: peers_mod.Donor) !u64 {
     // Covers the fetch AND the restore that streams the body: a donor can wedge at any
     // point, and the restore is where most of the time goes.
@@ -319,6 +385,7 @@ fn consumeLoop(c: *Consumer, start_version: u64) zio.Cancelable!void {
     var buf: [batch_size]Entry = undefined;
     var changes: [batch_size]Change = undefined;
     var after = start_version;
+    if (after == 0) after = try self.seedEmptyLineage(c);
     while (true) {
         const n = self.coordinator.read(c.name, c.generation, after, &buf, .none) catch |err| {
             if (err == error.Canceled) return error.Canceled;
@@ -777,6 +844,130 @@ test "bootstrapLineage swaps an index's data from a donor snapshot" {
 
     var q1 = [_]u32{ 100, 200 };
     try std.testing.expectEqual(@as(usize, 0), (try mi.search(a, "main", .{ .query = &q1 })).results.len);
+}
+
+test "bootstrapLineageFromSource builds, flushes and swaps in a corpus stream" {
+    const common = @import("common.zig");
+    const BootstrapStream = coordinator_mod.BootstrapStream;
+
+    const rt = try zio.Runtime.init(std.testing.allocator, .{});
+    defer rt.deinit();
+
+    const cwd = zio.Dir.cwd();
+    const dir_path = "test_bootstrap_source";
+    common.deleteDirTree(std.testing.allocator, cwd, dir_path) catch {};
+    try cwd.createDir(dir_path, 0o755);
+    defer common.deleteDirTree(std.testing.allocator, cwd, dir_path) catch {};
+    const dir = try cwd.openDir(dir_path, .{ .iterate = true });
+
+    var mi = MultiIndex.init(std.testing.allocator, dir);
+    defer mi.deinit();
+    _ = try mi.createIndex("main", .{ .generation = 1 });
+
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+    const a = arena.allocator();
+
+    // A doc the swap must make disappear.
+    _ = try mi.update(a, "main", .{ .changes = &[_]Change{.{ .insert = .{ .id = 1, .hashes = &.{ 100, 200 } } }} });
+
+    const Fake = struct {
+        batches: []const []const Change,
+        i: usize = 0,
+        const vt: BootstrapStream.VTable = .{ .next = nextImpl, .deinit = deinitImpl };
+        fn nextImpl(ptr: *anyopaque) anyerror!?[]const Change {
+            const self: *@This() = @ptrCast(@alignCast(ptr));
+            if (self.i >= self.batches.len) return null;
+            self.i += 1;
+            return self.batches[self.i - 1];
+        }
+        fn deinitImpl(_: *anyopaque) void {}
+    };
+    var fake = Fake{ .batches = &.{
+        &.{.{ .insert = .{ .id = 7, .hashes = &.{ 7, 8, 9 } } }},
+        &.{.{ .insert = .{ .id = 8, .hashes = &.{ 10, 11 } } }},
+    } };
+    var stream = BootstrapStream{ .ptr = &fake, .vtable = &Fake.vt, .position = 42 };
+
+    try std.testing.expectEqual(@as(u64, 42), try mi.bootstrapLineageFromSource("main", 1, &stream));
+
+    // The streamed corpus is searchable; the pre-existing doc is gone with the swap.
+    var q = [_]u32{ 7, 8, 9 };
+    const hit = try mi.search(a, "main", .{ .query = &q });
+    try std.testing.expectEqual(@as(usize, 1), hit.results.len);
+    try std.testing.expectEqual(@as(u32, 7), hit.results[0].id);
+    var q_old = [_]u32{ 100, 200 };
+    try std.testing.expectEqual(@as(usize, 0), (try mi.search(a, "main", .{ .query = &q_old })).results.len);
+
+    // Fully flushed: the position is durable in file segments, so this node can
+    // immediately donate a snapshot covering it — which is how the rest of a
+    // cluster avoids paying for the source stream again.
+    const st = try mi.getPeerStatus("main");
+    try std.testing.expectEqual(@as(u64, 42), st.version);
+    try std.testing.expectEqual(@as(u64, 42), st.file_version);
+}
+
+test "an empty node below a truncated log seeds from the source stream" {
+    const MemoryCoordinator = coordinator_mod.MemoryCoordinator;
+    const common = @import("common.zig");
+
+    const rt = try zio.Runtime.init(std.testing.allocator, .{ .executors = .exact(2) });
+    defer rt.deinit();
+
+    const cwd = zio.Dir.cwd();
+    const dir_path = "test_replicator_source_seed";
+    common.deleteDirTree(std.testing.allocator, cwd, dir_path) catch {};
+    try cwd.createDir(dir_path, 0o755);
+    defer common.deleteDirTree(std.testing.allocator, cwd, dir_path) catch {};
+    const dir = try cwd.openDir(dir_path, .{ .iterate = true });
+
+    var cl = MemoryCoordinator.init(std.testing.allocator);
+    defer cl.deinit();
+    const co = cl.coordinator();
+
+    // A populated lineage whose history is already unreadable from 0 — what a node
+    // joining an established cluster faces: a replay would 410 immediately, and
+    // without the stream (or a peer) it would wedge there forever.
+    const gen = try co.createIndex("main");
+    _ = try co.append("main", gen, &[_]Change{
+        .{ .insert = .{ .id = 1, .hashes = &.{ 10, 20 } } },
+        .{ .insert = .{ .id = 2, .hashes = &.{ 30, 40 } } },
+    }, null);
+    try cl.setRetentionFloor("main", gen, 2);
+
+    var mi = MultiIndex.init(std.testing.allocator, dir);
+    defer mi.deinit();
+    try mi.startReplication(co);
+
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+    const a = arena.allocator();
+
+    // The meta consumer builds the index; its empty data consumer must fill it from
+    // the bootstrap stream (no peers are configured), not wedge on BelowRetention.
+    var q = [_]u32{ 10, 20 };
+    var found = false;
+    var i: usize = 0;
+    while (i < 300) : (i += 1) {
+        const r = mi.search(a, "main", .{ .query = &q }) catch {
+            try zio.sleep(.fromMilliseconds(10));
+            continue;
+        };
+        if (r.results.len == 1 and r.results[0].id == 1) {
+            found = true;
+            break;
+        }
+        try zio.sleep(.fromMilliseconds(10));
+    }
+    try std.testing.expect(found);
+
+    // The consumer resumed the feed above the stream's position: a later write
+    // flows through normally, proving it did not wedge or restart from 0.
+    _ = try mi.update(a, "main", .{ .changes = &[_]Change{.{ .insert = .{ .id = 3, .hashes = &.{ 50, 60 } } }} });
+    var q3 = [_]u32{ 50, 60 };
+    const s3 = try mi.search(a, "main", .{ .query = &q3 });
+    try std.testing.expectEqual(@as(usize, 1), s3.results.len);
+    try std.testing.expectEqual(@as(u32, 3), s3.results[0].id);
 }
 
 test "meta consumer drops a local index absent from the meta feed" {

--- a/src/coordinator_server.zig
+++ b/src/coordinator_server.zig
@@ -9,6 +9,7 @@ const http = @import("dusty");
 const msgpack = @import("msgpack");
 const changelog_mod = @import("Coordinator.zig");
 const Coordinator = changelog_mod.Coordinator;
+const Change = @import("change.zig").Change;
 const Entry = changelog_mod.Entry;
 const MetaOp = changelog_mod.MetaOp;
 const AppendRequest = changelog_mod.AppendRequest;
@@ -46,7 +47,37 @@ pub fn registerRoutes(server: *Server) void {
     r.put("/_index/:index", handleCreateIndex);
     r.delete("/_index/:index", handleDeleteIndex);
     r.get("/_meta", handleReadMeta);
+    r.get("/_bootstrap/:index/:gen", handleBootstrap);
     r.post("/_truncate/:index/:gen", handleTruncate);
+}
+
+fn handleBootstrap(co: *Service, req: *http.Request, res: *http.Response) !void {
+    const index = req.params.get("index") orelse return fail(res, .bad_request, "missing index");
+    const generation = genParam(req) orelse return fail(res, .bad_request, "bad generation");
+
+    var stream = (co.coordinator.openBootstrap(index, generation) catch |err|
+        return fail(res, statusFor(err), @errorName(err))) orelse
+        return fail(res, .not_found, "no bootstrap stream");
+    defer stream.deinit();
+
+    // Same wire shape as the PG feed: a msgpack header, then arrays of changes,
+    // terminated by an empty array. Chunked, so nothing buffers the whole corpus;
+    // a mid-stream failure just breaks the connection, which the client reads as
+    // truncation (no terminator) — never as completion.
+    try res.header("Content-Type", comptime http.ContentType.msgpack.toContentType());
+    var aw: std.Io.Writer.Allocating = .init(req.arena);
+    try msgpack.encode(changelog_mod.BootstrapHeader{ .position = stream.position }, &aw.writer);
+    try res.chunk(aw.written());
+
+    while (try stream.next()) |changes| {
+        if (changes.len == 0) continue; // the empty array is the terminator, nothing else
+        aw.clearRetainingCapacity();
+        try msgpack.encode(changes, &aw.writer);
+        try res.chunk(aw.written());
+    }
+    aw.clearRetainingCapacity();
+    try msgpack.encode(@as([]const Change, &.{}), &aw.writer);
+    try res.chunk(aw.written());
 }
 
 fn handleTruncate(co: *Service, req: *http.Request, res: *http.Response) !void {

--- a/src/server.zig
+++ b/src/server.zig
@@ -175,11 +175,18 @@ fn handleHealth(_: *MultiIndex, _: *http.Request, res: *http.Response) !void {
 }
 
 fn handleIndexHealth(mi: *MultiIndex, req: *http.Request, res: *http.Response) !void {
-    const exists = mi.checkIndexExists(indexName(req)) catch |err| return sendError(req, res, err);
-    if (exists) {
-        res.body = "OK\n";
-    } else {
-        res.status = .not_found;
+    switch (mi.indexHealth(indexName(req)) catch |err| return sendError(req, res, err)) {
+        .ready => res.body = "OK\n",
+        // 503 + a distinct body: the index exists but is being filled by a
+        // bootstrap (initial seed or below-retention restore), and every search
+        // it answered would be honest-looking but empty or stale. Non-2xx keeps a
+        // search balancer's readiness probe from routing traffic here until the
+        // bootstrap installs.
+        .loading => {
+            res.status = .service_unavailable;
+            res.body = "LOADING\n";
+        },
+        .missing => res.status = .not_found,
     }
 }
 

--- a/tests/test_cluster.py
+++ b/tests/test_cluster.py
@@ -253,3 +253,51 @@ def test_new_node_bootstraps_from_peer(tmp_path):
             p.send_signal(signal.SIGKILL)
         for p in procs:
             p.wait()
+
+
+def test_new_node_bootstraps_from_the_feeds_source_stream(tmp_path):
+    """A new node with NO peers joins after the changelog is truncated past 0: the
+    feed's own bootstrap stream (GET /_bootstrap — the same protocol acoustid-server
+    serves from PostgreSQL) fills it, and the feed resumes above the stream's
+    position."""
+    if not os.path.exists(BINARY):
+        subprocess.run(["zig", "build"], cwd=REPO_ROOT, check=True)
+
+    co, p1, p2 = _free_port(), _free_port(), _free_port()
+    procs = []
+
+    def start(args):
+        procs.append(subprocess.Popen([BINARY] + args))
+
+    try:
+        start(["--coordinator", "--port", str(co)])
+        _wait(co, "/_changelog/x/1?after=0&max=1&timeout_ms=50")
+        url = f"http://127.0.0.1:{co}"
+
+        start(["--port", str(p1), "--dir", str(tmp_path / "r1"), "--coordinator-url", url])
+        _wait(p1, "/_health")
+        _req(p1, "PUT", "/main")
+        _req(p1, "PUT", "/main/1", {"hashes": [10, 20, 30]})
+        _req(p1, "PUT", "/main/2", {"hashes": [40, 50, 60]})
+        assert _search_has(p1, [10, 20, 30], 1)
+
+        # Truncate below the corpus: a replay from 0 is now impossible, and with no
+        # peers configured the source stream is the only way in.
+        req = urllib.request.Request(f"http://127.0.0.1:{co}/_truncate/main/1?floor=1", method="POST")
+        assert urllib.request.urlopen(req, timeout=5).status == 200
+
+        start(["--port", str(p2), "--dir", str(tmp_path / "r2"), "--coordinator-url", url])
+        _wait(p2, "/_health")
+        assert _wait_index(p2, "main")
+        assert _search_has(p2, [10, 20, 30], 1)
+        assert _search_has(p2, [40, 50, 60], 2)
+
+        # And the feed resumed above the stream's position: a fresh write reaches
+        # the bootstrapped node through the normal consumer path.
+        _req(p1, "PUT", "/main/3", {"hashes": [70, 80, 90]})
+        assert _search_has(p2, [70, 80, 90], 3)
+    finally:
+        for p in procs:
+            p.send_signal(signal.SIGKILL)
+        for p in procs:
+            p.wait()

--- a/tests/test_cluster.py
+++ b/tests/test_cluster.py
@@ -53,7 +53,12 @@ def _req(port, method, path, body=None):
 
 
 def _search(port, query):
-    return _req(port, "POST", "/main/_search", {"query": query}).get("results", [])
+    try:
+        return _req(port, "POST", "/main/_search", {"query": query}).get("results", [])
+    except urllib.error.HTTPError as e:
+        if e.code == 503:  # still bootstrapping: refused, not empty — poll on
+            return []
+        raise
 
 
 def _search_has(port, query, want_id, tries=50):


### PR DESCRIPTION
The client half of [acoustid-server#242](https://github.com/acoustid/acoustid-server/pull/242). Stacked on #150 (`feed-protocol`), which it builds on; the diff here is only the bootstrap work.

The PG changelog starts at the migration, so an empty index replaying it from 0 builds a corpus silently missing every fingerprint older than the log — while being told "caught up". This adds the node-side path #242's "Not covered" section called for.

## The capability is the feed's declaration

`Coordinator.openBootstrap` is an **optional** vtable op. Implementing it says "my history starts later than my corpus; an empty index must not replay from 0". The file log doesn't implement it — standalone replay stays the bootstrap. `MemoryCoordinator` and `RemoteCoordinator` do, and `coordinator_server` serves the same wire shape as the PG feed, so the two remain interchangeable behind `RemoteCoordinator` and the e2e suite exercises the real client path without PostgreSQL.

## Seeding order for an empty consumer

A consumer starting at version 0 seeds **before its first read**:

1. **Peer snapshot** — the corpus already built inside the cluster beats pulling a terabyte back out of PostgreSQL.
2. **The source stream** — one node pays this once per cluster; because the build is fully flushed, that node immediately becomes a donor for the rest.
3. **Plain replay from 0** — feeds with complete history neither need nor offer the stream.

Deliberately **not** wired into the below-retention path: a whole cluster falling off the log would stampede the source with N corpus streams. That remedy stays operator-driven — wipe one node, which makes it empty and lands it in the seed path. Same reasoning bounds cold start: bring nodes up one at a time on first fill, since concurrently-started empty nodes cannot see each other as donors until one finishes.

## Staging + swap, never in place

The stream applies into `v<gen>/bootstrap.tmp` at the header's single position (#149's non-decreasing rule is what makes that legal), is flushed fully to disk — `Index.flush`, a force-checkpoint the threshold and age triggers cannot provide, because the install path reopens from disk alone and discards the staging WAL — and installs through the same drain-and-swap path as a peer-snapshot restore. Applying in place would let a mid-stream death leave a node claiming `position` with 1% of the data, resuming *above* it, with the missing 99% never sent again. A dead staging build is just a directory the next attempt deletes.

## Done versus died

The decode treats the empty-array terminator as the only completion signal: end-of-stream without it surfaces as `error.EndOfStream` from the msgpack layer, never as a shorter corpus. The wire format is pinned against hand-written bytes (`0x81 0xa1 'p' …`) rather than round-tripped through our own encoder — the same discipline the Python side uses — which closes half of #150's "nothing pins the wire format against the Python encoder" gap.

## Health and search during a bootstrap

A node mid-bootstrap would answer every search with an honest-looking result that is empty (initial seed) or stale (below-retention restore). So while a consumer fills its index by bootstrap, `/:index/_health` answers **503 `LOADING`** and `/:index/_search` refuses with `IndexNotReady` (→ 503) — a balancer's readiness probe drains the node, and a caller that skipped the probe still can't mistake loading for a miss. The flag is sticky across failed bootstrap attempts, so the gap between retries never flashes OK. Global `/_health` and `/:index/_status` stay independent of this on purpose: peer discovery must keep finding open-but-loading nodes, or a cold cluster start deadlocks (the Kubernetes trap in `notes/bootstrap-design.md`). A fresh lineage is briefly `LOADING` too, while its consumer decides whether there is anything to load.

## Backstops

The whole open-and-stream is bounded by the existing `--bootstrap-timeout-ms` (default 30 min), reported as `error.BootstrapTimeout` and retried, so a source that accepts the connection and then wedges cannot hang the consumer forever. Real 100M-row fills that legitimately stream longer need the flag raised — same caveat the snapshot transfer already carries.

## Tested

`zig build unit-tests`: **106 passed** (97 before). New: `Index.flush` below-threshold checkpoint; `MemoryCoordinator` bootstrap (retention notwithstanding, empty lineage → position 0); wire pinning incl. truncation-is-an-error; `bootstrapLineageFromSource` staging/swap/donor-readiness; a corpus streamed at position 0 installing (see below); an empty node below a truncated log seeding end-to-end and resuming the feed above the position.

`zig build e2e-tests`: **48 passed** (47 before). New: a node with no peers joining a truncated feed over real HTTP — bootstraps from the stream, then receives a fresh write through the normal consumer path.

**Manually, against the real PostgreSQL feed** — acoustid-server's `fpindex-bootstrap` branch serving `acoustid_test`, no test doubles anywhere. The DB was put in the true migration state: 200 fingerprints whose changelog rows were wiped (corpus predates the log) plus one post-migration submission at changelog id 420, which sits in **both** the stream and the feed:

1. A fresh node with `--coordinator-url` seeds itself: `bootstrapping 'acoustid' gen 1 from a source stream at position 420`, one checkpoint of 1608 items (201 docs × 8 terms), `/_status` → `{generation: 1, version: 420, file_version: 420}` — donor-ready immediately.
2. A pre-log corpus fingerprint (no changelog row anywhere) searches at full score; the overlap fingerprint searches once, not twice (upsert).
3. `INSERT INTO fingerprint …` in PG → changelog 421 → the node applies it within the pacing interval; `/_status` → `version: 421, file_version: 420`.
4. A second empty node started with `--peers` takes the **peer snapshot** (`bootstrapping 'acoustid' gen 1 from http://…:8091 (watermark 420)`) instead of pulling the corpus from PG again, then catches up to 421 from the feed — the "one node pays" preference order, live.
5. Restarting node 1 reopens at 421 from disk (`opened index 'acoustid' at version 421`), zero bootstrap lines — no re-seed.

Setting this up caught a real bug, fixed in the second commit: the seed path short-circuited on `position == 0`, but a changelog that went live next to an old corpus and has recorded nothing yet legitimately reports 0 **with a full stream** — the primary migration case. It would have replayed from 0 and silently missed the entire corpus. Whether anything installs is now decided by the stream's content, never its position.

## Not covered

- No progress logging during a long stream; a 61 GB fill is silent until it finishes.
