### PR TITLE
Publish a container image from main again

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+*
+!zig-out/bin/fpindex

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,11 +6,20 @@ on:
     tags: ['v*']
   pull_request:
 
+# The repository default is write-all, which every job here would otherwise
+# inherit while running code from the pull request.
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          # Otherwise the token is left in .git/config, readable by the build
+          # and test code below. Nothing here pushes, so it is not needed.
+          persist-credentials: false
 
       - uses: mlugg/setup-zig@v2
         with:
@@ -42,6 +51,8 @@ jobs:
       packages: write
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - uses: mlugg/setup-zig@v2
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   push:
-    branches: [ng, main]
+    branches: [main]
   pull_request:
 
 jobs:
@@ -30,3 +30,43 @@ jobs:
 
       - name: Integration tests
         run: zig build e2e-tests
+
+  docker:
+    # Pinned rather than ubuntu-latest: the release binary is copied into an
+    # ubuntu:24.04 image and links this runner's glibc, so the two must match.
+    runs-on: ubuntu-24.04
+    needs: test
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: mlugg/setup-zig@v2
+        with:
+          version: 0.16.0
+
+      - name: Build release binary
+        run: zig build --release=fast --summary all
+
+      - name: Log in to the Container registry
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,7 @@ name: CI
 on:
   push:
     branches: [main]
+    tags: ['v*']
   pull_request:
 
 jobs:
@@ -57,6 +58,10 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      # Default rules, which suit calver as-is: a branch push tags the image
+      # after the branch, a vY.M.p tag after the tag verbatim, and `latest=auto`
+      # moves `latest` on a tag push but never on a branch push. Adding semver
+      # patterns here would drop the `v` and choke on a zero-padded month.
       - name: Extract metadata (tags, labels) for Docker
         id: meta
         uses: docker/metadata-action@v5

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,22 @@
+FROM ubuntu:24.04
+
+# wget is here for container healthchecks (GET /_health); nothing in the server
+# needs it.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends wget \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN useradd -m -s /bin/bash -u 6081 acoustid
+
+RUN mkdir -p /var/lib/fpindex && chown acoustid /var/lib/fpindex
+VOLUME ["/var/lib/fpindex"]
+
+# Built outside by `zig build --release=fast`, not in a builder stage, so the
+# image is only buildable after that has run. The binary links the runner's
+# glibc, which is why CI pins ubuntu-24.04 to match this base.
+COPY --chmod=755 zig-out/bin/fpindex /usr/bin/fpindex
+
+USER acoustid
+EXPOSE 8080
+
+CMD ["fpindex", "--dir", "/var/lib/fpindex", "--host", "0.0.0.0", "--port", "8080"]

--- a/README.md
+++ b/README.md
@@ -29,6 +29,24 @@ speaking the same protocol (acoustid-server serves it from PostgreSQL).
         --coordinator-url http://coordinator:9000 \
         --peers http://fpindex-headless:8080
 
+### Docker
+
+`ghcr.io/acoustid/acoustid-index:main` is built from `main` on every push. It
+serves on 8080 and keeps data in the `/var/lib/fpindex` volume, as user 6081.
+
+    docker run --security-opt seccomp=unconfined \
+        -p 8080:8080 -v fpindex-data:/var/lib/fpindex \
+        ghcr.io/acoustid/acoustid-index:main
+
+**`--security-opt seccomp=unconfined` is required.** Docker's default seccomp
+profile blocks `io_uring_setup`, which the async runtime needs; without it the
+server exits immediately with `error: PermissionDenied`. A custom profile that
+allows the `io_uring_*` syscalls works too. Kubernetes only hits this if the pod
+sets `seccompProfile: RuntimeDefault`.
+
+The image is built from a binary produced outside it (`zig build --release=fast`),
+so `docker build .` on a clean checkout fails until that has run.
+
 ## Configuration
 
 | Flag | Default | Meaning |

--- a/README.md
+++ b/README.md
@@ -31,8 +31,11 @@ speaking the same protocol (acoustid-server serves it from PostgreSQL).
 
 ### Docker
 
-`ghcr.io/acoustid/acoustid-index:main` is built from `main` on every push. It
-serves on 8080 and keeps data in the `/var/lib/fpindex` volume, as user 6081.
+`ghcr.io/acoustid/acoustid-index` is built from `main` on every push, tagged
+`:main`. Pushing a release tag `vY.M.p` publishes `:vY.M.p` and moves `:latest`
+onto it — `:latest` follows the most recently pushed tag, so tagging an older
+release after a newer one would move it backwards. It serves on 8080 and keeps
+data in the `/var/lib/fpindex` volume, as user 6081.
 
     docker run --security-opt seccomp=unconfined \
         -p 8080:8080 -v fpindex-data:/var/lib/fpindex \


### PR DESCRIPTION
## Why

The `main` → `v3`, `ng` → `main` rename left the repo publishing no container
image at all:

- `v3`'s `build.yml` and `build-legacy-proxy.yml` still trigger on
  `branches: [ main ]`, a name that branch no longer has, so nothing on v3
  builds.
- this branch's `ci.yml` only ever ran tests — there was no `Dockerfile` here.

## What

A `docker` job on `ci.yml` that builds the release binary and pushes to
`ghcr.io/acoustid/acoustid-index`, plus the `Dockerfile` it needs. Same shape as
the one v3 built — `ubuntu:24.04`, binary copied in rather than a builder stage,
`docker/metadata-action` for tags — but rewired to this server:

| | v3 image | here |
| --- | --- | --- |
| listen flag | `--address` | `--host` |
| port | 6081 | 8080 |
| data dir | `/var/lib/acoustid-index` | `/var/lib/fpindex` |

`parseArgs` only *warns* about an unknown flag, so a copied `--address 0.0.0.0`
would have silently left the server on the default `127.0.0.1` and looked
healthy from inside the container. The port and path follow this branch's own
defaults and README rather than v3's; nothing consumes the `:main` tag today
(`acoustid-server` pins `:stable` and `:v2022.02.03`), so there is no contract
to preserve.

Also drops `ng` from the CI triggers — that branch is gone.

## Release tags

The workflow runs on `tags: ['v*']` as well as pushes to `main`. Without that
filter it would not run on a tag push at all, and `latest` would never be
written — a branch push does not produce `latest` under metadata-action's
default `latest=auto`.

The action's default tag rules are left alone, because they already suit this
project's calver:

| push | image tags |
| --- | --- |
| `main` | `:main` |
| tag `v25.4.1` | `:v25.4.1`, `:latest` |
| pull request | built, not pushed |

`type=ref,event=tag` emits the tag name verbatim, keeping the `v` prefix that
`:v2022.02.03` already established. Semver patterns would be wrong twice over:
they strip the `v`, and a zero-padded month (`v25.04.1`) is not valid semver, so
such a tag would silently produce no version tags at all.

One caveat, documented in the README: `latest` follows the most recently *pushed*
tag, not the highest version. Tagging an older release after a newer one moves
it backwards.

## The seccomp catch

The image does not run under Docker's defaults. Verified on this box, all four
combinations:

| flags | result |
| --- | --- |
| default | `error: PermissionDenied`, exit 1 |
| `--ulimit memlock=-1` | `error: PermissionDenied`, exit 1 |
| `--security-opt seccomp=unconfined` | starts, serves |
| both | starts, serves |

Docker's default seccomp profile blocks `io_uring_setup`, which zio needs; it is
not the mlock in the storage layer, which was the likelier-looking suspect. The
image cannot fix this, so it is documented next to the run command in the README.
Kubernetes is unaffected unless a pod sets `seccompProfile: RuntimeDefault`.

## Testing

- `zig build unit-tests` — pass.
- `zig build e2e-tests` — 48 passed.
- Built the image locally and ran it: health OK, index create → insert → search
  returned `{"results":[{"id":1,"score":5}]}`, running as uid 6081, data written
  under `/var/lib/fpindex`.
- The CI job itself is unrun until this lands — `docker/build-push-action` only
  builds, so the seccomp issue does not affect it, but the ghcr push path is
  unexercised. The tag behaviour above is from the action's documented default
  rules, not from an observed run.

## Not covered

- **`v3` still builds nothing.** Its triggers need `[ v3 ]`, which also changes
  the published tag from `main` to `v3` — a call for whoever owns the deploy,
  not part of this.
- **No `legacy-proxy` image here.** v3 published one; this branch speaks the
  legacy line protocol natively via `--legacy-port`, so it may simply not be
  needed, but that is worth a deliberate decision rather than my assumption.
- **`error: PermissionDenied` with no context** is a poor way to learn about the
  seccomp profile. Improving that message is a separate change.