### PR TITLE
Expose the applied version per index as a gauge

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ and `Accept`.
 | Endpoint | Meaning |
 | --- | --- |
 | `GET /_health` | Process liveness. Always `200 OK` while the process runs. |
-| `GET /_metrics` | Prometheus metrics. |
+| `GET /_metrics` | Prometheus metrics. Process-wide counters and histograms, plus `fpindex_docs` and `fpindex_version` gauges labelled by index. |
 | `GET /:index/_health` | Index readiness: `200 OK` when serving, `503 LOADING` while the index is being filled by a bootstrap, `404` if it does not exist. |
 | `PUT /:index` | Create an index. Body: `{"expect_does_not_exist": bool, "generation": u64}` (both optional). Idempotent. |
 | `DELETE /:index` | Delete an index. Body: `{"expect_exists": bool}` (optional). |

--- a/src/MultiIndex.zig
+++ b/src/MultiIndex.zig
@@ -387,7 +387,7 @@ pub fn applyLog(self: *Self, name: []const u8, generation: u64, changes: []const
     _ = try index.update(changes, .{ .version = version });
 }
 
-/// Render metrics (global counters + a per-index docs gauge) in Prometheus text.
+/// Render metrics (global counters + per-index gauges) in Prometheus text.
 /// Holds the manager lock across the (brief) scrape.
 pub fn writeMetrics(self: *Self, w: *std.Io.Writer) !void {
     try metrics.writeGlobal(w);
@@ -395,12 +395,23 @@ pub fn writeMetrics(self: *Self, w: *std.Io.Writer) !void {
     try self.lock.lock();
     defer self.lock.unlock();
 
+    // One pass per family: the text format wants every sample of a family under
+    // a single HELP/TYPE, so the families cannot be interleaved per index. The
+    // lock is held throughout, so the set of indexes is the same in each pass.
     try w.writeAll("# HELP fpindex_docs Number of documents in an index\n# TYPE fpindex_docs gauge\n");
-    var it = self.indexes.iterator();
-    while (it.next()) |entry| {
+    var docs_it = self.indexes.iterator();
+    while (docs_it.next()) |entry| {
         var reader = try entry.value_ptr.*.index.acquireReader();
         defer reader.deinit();
         try w.print("fpindex_docs{{index=\"{s}\"}} {d}\n", .{ entry.key_ptr.*, reader.numDocs() });
+    }
+
+    try w.writeAll("# HELP fpindex_version Last changelog position applied to an index\n# TYPE fpindex_version gauge\n");
+    var version_it = self.indexes.iterator();
+    while (version_it.next()) |entry| {
+        var reader = try entry.value_ptr.*.index.acquireReader();
+        defer reader.deinit();
+        try w.print("fpindex_version{{index=\"{s}\"}} {d}\n", .{ entry.key_ptr.*, reader.version() });
     }
 }
 

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -1,3 +1,6 @@
+import json
+
+
 def test_health(client):
     req = client.get('/_health')
     assert req.status_code == 200, req.content
@@ -14,3 +17,19 @@ def test_metrics(client):
     assert 'fpindex_searches_total' in req.text
     assert 'fpindex_search_hits_total' in req.text
     assert 'fpindex_search_misses_total' in req.text
+
+
+def test_index_gauges(client, index_name, create_index):
+    req = client.post(f'/{index_name}/_update', json={
+        'changes': [
+            {'insert': {'id': 1, 'hashes': [100, 200, 300]}},
+            {'insert': {'id': 2, 'hashes': [400, 500, 600]}},
+        ],
+    })
+    assert req.status_code == 200, req.content
+    version = json.loads(req.content)['version']
+
+    req = client.get('/_metrics')
+    assert req.status_code == 200, req.content
+    assert f'fpindex_docs{{index="{index_name}"}} 2' in req.text
+    assert f'fpindex_version{{index="{index_name}"}} {version}' in req.text


### PR DESCRIPTION
`/_metrics` had a `fpindex_docs` gauge per index but nothing about how far each
index had been applied. A replica falling behind the changelog was invisible to
a scrape — the watermark was only reachable by polling `GET /:index/_status`,
one request per index.

    # HELP fpindex_docs Number of documents in an index
    # TYPE fpindex_docs gauge
    fpindex_docs{index="beta"} 1
    fpindex_docs{index="alpha"} 2
    # HELP fpindex_version Last changelog position applied to an index
    # TYPE fpindex_version gauge
    fpindex_version{index="beta"} 1
    fpindex_version{index="alpha"} 1

`fpindex_version` is `IndexReader.version()` — the same value `_status` reports,
the upstream changelog position, not the internal commit id.

## Why a second pass

The new gauge is rendered in its own loop over the indexes rather than printed
next to the docs gauge. The Prometheus text format wants every sample of a
family grouped under a single `HELP`/`TYPE`, so emitting both per index would
interleave the families and repeat the headers. The manager lock is held across
both passes, so they see the same set of indexes; only a per-index snapshot can
advance between them, which for gauges is fine.

## Testing

- `zig build unit-tests` — pass.
- `zig build e2e-tests` — 49 passed (48 before).
- New `test_index_gauges` asserts both gauges against an index with a known doc
  count and the version returned by `_update`. Verified it fails without the
  change (`assert 'fpindex_version{index=...' in req.text`) and passes with it.
- Scraped a real server with two indexes to confirm the families come out
  grouped, as above.

## Not covered

- **`file_version` and `generation` are still not exposed.** Both are on the
  same reader and would each be another pass. `file_version` is the more useful
  of the two — it is the snapshot watermark, so `version - file_version` is how
  much a donor cannot yet serve. Left out because it was not asked for; say the
  word.
- **`version` resets on a delete + recreate**, since a new lineage restarts the
  changelog position. Without a `generation` gauge next to it, that reads as the
  counter going backwards. Worth deciding on together with the point above.
- **Replication itself remains untracked** — no metric anywhere in
  `Replicator.zig`, `RemoteCoordinator.zig`, `Coordinator.zig` or `Oplog.zig`.
  No consumer lag, bootstrap duration, or snapshot transfer counts. This gauge
  makes lag *derivable* by comparing nodes, but does not measure it directly.