### PR TITLE
Add fpindex_version and move per-index gauges to GaugeVec

### DIFF
--- a/src/MultiIndex.zig
+++ b/src/MultiIndex.zig
@@ -297,7 +297,7 @@ pub fn search(self: *Self, arena: std.mem.Allocator, name: []const u8, request: 
     if (self.replication) |repl| {
         if (repl.isBootstrapping(name)) return error.IndexNotReady;
     }
-    metrics.incSearches();
+    metrics.incSearches(name);
 
     const collector = try self.results_pool.acquire(.{
         .max_results = request.limit,
@@ -320,10 +320,10 @@ pub fn search(self: *Self, arena: std.mem.Allocator, name: []const u8, request: 
         if (err == error.Canceled and deadline.check(error.Canceled)) return error.SearchTimeout;
         return err;
     };
-    metrics.observeSearchSeconds(@as(f64, @floatFromInt(sw.read().toNanoseconds())) / 1_000_000_000.0);
+    metrics.observeSearchSeconds(name, @as(f64, @floatFromInt(sw.read().toNanoseconds())) / 1_000_000_000.0);
 
     const results = collector.getResults();
-    if (results.len > 0) metrics.incSearchHit() else metrics.incSearchMiss();
+    if (results.len > 0) metrics.incSearchHit(name) else metrics.incSearchMiss(name);
     const out = try arena.alloc(api.SearchResult, results.len);
     for (results, 0..) |r, i| out[i] = .{ .id = r.id, .score = r.score };
     return .{ .results = out };
@@ -351,7 +351,7 @@ pub fn update(self: *Self, arena: std.mem.Allocator, name: []const u8, request: 
 
     const index = try self.getIndex(name);
     defer self.releaseIndex(index);
-    metrics.incUpdates();
+    metrics.incUpdates(name);
     const version = try index.update(changes, .{ .expected_version = request.expected_version });
     return .{ .version = version };
 }
@@ -383,7 +383,7 @@ fn foldMetadata(arena: std.mem.Allocator, changes: []const Change, metadata: ?Me
 pub fn applyLog(self: *Self, name: []const u8, generation: u64, changes: []const Change, version: u64) !void {
     const index = try self.getIndexForGeneration(name, generation);
     defer self.releaseIndex(index);
-    metrics.incUpdates();
+    metrics.incUpdates(name);
     _ = try index.update(changes, .{ .version = version });
 }
 

--- a/src/MultiIndex.zig
+++ b/src/MultiIndex.zig
@@ -387,21 +387,25 @@ pub fn applyLog(self: *Self, name: []const u8, generation: u64, changes: []const
     _ = try index.update(changes, .{ .version = version });
 }
 
-/// Render metrics (global counters + a per-index docs gauge) in Prometheus text.
-/// Holds the manager lock across the (brief) scrape.
+/// Render metrics in Prometheus text. The per-index gauges are refreshed here,
+/// at scrape time, from one snapshot per index — they have no other writer, so
+/// they can't drift from the real index state. Holds the manager lock across
+/// the (brief) refresh.
 pub fn writeMetrics(self: *Self, w: *std.Io.Writer) !void {
-    try metrics.writeGlobal(w);
+    {
+        try self.lock.lock();
+        defer self.lock.unlock();
 
-    try self.lock.lock();
-    defer self.lock.unlock();
-
-    try w.writeAll("# HELP fpindex_docs Number of documents in an index\n# TYPE fpindex_docs gauge\n");
-    var it = self.indexes.iterator();
-    while (it.next()) |entry| {
-        var reader = try entry.value_ptr.*.index.acquireReader();
-        defer reader.deinit();
-        try w.print("fpindex_docs{{index=\"{s}\"}} {d}\n", .{ entry.key_ptr.*, reader.numDocs() });
+        var it = self.indexes.iterator();
+        while (it.next()) |entry| {
+            const name = entry.key_ptr.*;
+            var reader = try entry.value_ptr.*.index.acquireReader();
+            defer reader.deinit();
+            try metrics.setDocs(name, reader.numDocs());
+            try metrics.setVersion(name, reader.version());
+        }
     }
+    try metrics.write(w);
 }
 
 pub fn checkIndexExists(self: *Self, name: []const u8) !bool {
@@ -775,6 +779,7 @@ fn installBootstrap(self: *Self, name: []const u8, generation: u64, name_dir: zi
         const kv = self.indexes.fetchRemove(name).?;
         self.allocator.free(kv.key);
         self.allocator.destroy(kv.value);
+        metrics.removeIndex(name);
         return err;
     };
     ref.being_deleted = false;
@@ -833,6 +838,7 @@ fn dropIndex(self: *Self, name: []const u8) !DropResult {
     kv.value.index.deinit();
     self.allocator.destroy(kv.value);
     self.allocator.free(kv.key);
+    metrics.removeIndex(name);
     // Mark the redirect deleted and drop the generation's data dir; keep
     // data/<name>/ + current so a recreate can bump to the next generation.
     self.markDeleted(name, gen) catch |err| {

--- a/src/main.zig
+++ b/src/main.zig
@@ -71,6 +71,10 @@ const server_config: http.ServerConfig = .{ .request = .{ .max_body_size = 16 * 
 fn runServer(allocator: std.mem.Allocator, rt: *zio.Runtime, config: Config) !void {
     const io = rt.io();
 
+    // Here rather than main() because the labelled vecs need an Io for their locks.
+    try metrics.init(allocator, io, .{});
+    defer metrics.deinit();
+
     if (config.coordinator) return runCoordinator(allocator, io, config);
 
     const cwd = zio.Dir.cwd();
@@ -262,8 +266,6 @@ pub fn main(init: std.process.Init.Minimal) !void {
     const allocator = root_allocator.allocator();
 
     const config = try parseArgs(init.args);
-
-    metrics.init(.{});
 
     // Multiple executors so searches, updates, and merges spread across cores.
     // The index is thread-safe: reads work on a refcounted snapshot, the segment

--- a/src/metrics.zig
+++ b/src/metrics.zig
@@ -1,6 +1,7 @@
-// Global process metrics, backed by karlseguin/metrics.zig (Prometheus). Global
-// counters + a search-duration histogram live here; per-index gauges are
-// rendered on demand by MultiIndex (it holds the indexes).
+// Global process metrics, backed by karlseguin/metrics.zig (Prometheus).
+// Counters and histograms are recorded as events happen; the per-index gauges
+// are refreshed from the live indexes at scrape time (MultiIndex.writeMetrics)
+// and removed when an index is dropped.
 
 const std = @import("std");
 const m = @import("metrics");
@@ -8,6 +9,9 @@ const m = @import("metrics");
 const SearchDuration = m.Histogram(f64, &.{ 0.001, 0.005, 0.01, 0.05, 0.1, 0.5, 1, 5 });
 const ScannedDocs = m.Histogram(u64, &.{ 1, 2, 3, 5, 10, 50, 100, 500, 1000 });
 const ScannedBlocks = m.Histogram(u64, &.{ 1, 2, 3, 5, 10 });
+
+const IndexLabels = struct { index: []const u8 };
+const IndexGauge = m.GaugeVec(u64, IndexLabels);
 
 const Metrics = struct {
     searches: m.Counter(u64),
@@ -20,14 +24,16 @@ const Metrics = struct {
     search_duration: SearchDuration,
     scanned_docs_per_hash: ScannedDocs,
     scanned_blocks_per_hash: ScannedBlocks,
+    docs: IndexGauge,
+    version: IndexGauge,
 };
 
 // No-op until init(); calls before then just don't record (never crash).
 var metrics = m.initializeNoop(Metrics);
 
-/// Wire up real metrics. Call once at startup. No allocation — counters and
-/// histograms are inline (only labelled vecs would need an allocator).
-pub fn init(comptime opts: m.RegistryOpts) void {
+/// Wire up real metrics. Call once at startup. The allocator and io are only
+/// used by the labelled vecs (label sets are duplicated into the allocator).
+pub fn init(allocator: std.mem.Allocator, io: std.Io, comptime opts: m.RegistryOpts) !void {
     metrics = .{
         .searches = m.Counter(u64).init("fpindex_searches_total", .{}, opts),
         .search_hits = m.Counter(u64).init("fpindex_search_hits_total", .{}, opts),
@@ -39,7 +45,15 @@ pub fn init(comptime opts: m.RegistryOpts) void {
         .search_duration = SearchDuration.init("fpindex_search_duration_seconds", .{}, opts),
         .scanned_docs_per_hash = ScannedDocs.init("fpindex_scanned_docs_per_hash", .{}, opts),
         .scanned_blocks_per_hash = ScannedBlocks.init("fpindex_scanned_blocks_per_hash", .{}, opts),
+        .docs = try IndexGauge.init(allocator, io, "fpindex_docs", .{ .help = "Number of documents in an index" }, opts),
+        .version = try IndexGauge.init(allocator, io, "fpindex_version", .{ .help = "Upstream changelog position the index reflects" }, opts),
     };
+}
+
+pub fn deinit() void {
+    metrics.docs.deinit();
+    metrics.version.deinit();
+    metrics = m.initializeNoop(Metrics);
 }
 
 pub fn incSearches() void {
@@ -73,7 +87,21 @@ pub fn observeScannedBlocksPerHash(n: u64) void {
     metrics.scanned_blocks_per_hash.observe(n);
 }
 
-/// Render the global metrics in Prometheus text format.
-pub fn writeGlobal(w: *std.Io.Writer) !void {
+pub fn setDocs(index_name: []const u8, n: u64) !void {
+    try metrics.docs.set(.{ .index = index_name }, n);
+}
+pub fn setVersion(index_name: []const u8, v: u64) !void {
+    try metrics.version.set(.{ .index = index_name }, v);
+}
+/// Drop all per-index series for a deleted index; without this the stale
+/// values would be scraped until restart.
+pub fn removeIndex(index_name: []const u8) void {
+    metrics.docs.remove(.{ .index = index_name });
+    metrics.version.remove(.{ .index = index_name });
+}
+
+/// Render all metrics in Prometheus text format. Callers who need the
+/// per-index gauges fresh must set them first (see MultiIndex.writeMetrics).
+pub fn write(w: *std.Io.Writer) !void {
     return m.write(&metrics, w);
 }

--- a/src/metrics.zig
+++ b/src/metrics.zig
@@ -6,18 +6,23 @@
 const std = @import("std");
 const m = @import("metrics");
 
-const SearchDuration = m.Histogram(f64, &.{ 0.001, 0.005, 0.01, 0.05, 0.1, 0.5, 1, 5 });
 const ScannedDocs = m.Histogram(u64, &.{ 1, 2, 3, 5, 10, 50, 100, 500, 1000 });
 const ScannedBlocks = m.Histogram(u64, &.{ 1, 2, 3, 5, 10 });
 
 const IndexLabels = struct { index: []const u8 };
+const IndexCounter = m.CounterVec(u64, IndexLabels);
 const IndexGauge = m.GaugeVec(u64, IndexLabels);
+const SearchDuration = m.HistogramVec(f64, IndexLabels, &.{ 0.001, 0.005, 0.01, 0.05, 0.1, 0.5, 1, 5 });
 
+// The request-level metrics are labelled per index (MultiIndex knows the name);
+// the segment- and background-level ones (scans, checkpoints, merges) stay
+// global — those layers don't know the index name and per-index resolution
+// isn't worth threading it down.
 const Metrics = struct {
-    searches: m.Counter(u64),
-    search_hits: m.Counter(u64),
-    search_misses: m.Counter(u64),
-    updates: m.Counter(u64),
+    searches: IndexCounter,
+    search_hits: IndexCounter,
+    search_misses: IndexCounter,
+    updates: IndexCounter,
     checkpoints: m.Counter(u64),
     memory_merges: m.Counter(u64),
     file_merges: m.Counter(u64),
@@ -35,14 +40,14 @@ var metrics = m.initializeNoop(Metrics);
 /// used by the labelled vecs (label sets are duplicated into the allocator).
 pub fn init(allocator: std.mem.Allocator, io: std.Io, comptime opts: m.RegistryOpts) !void {
     metrics = .{
-        .searches = m.Counter(u64).init("fpindex_searches_total", .{}, opts),
-        .search_hits = m.Counter(u64).init("fpindex_search_hits_total", .{}, opts),
-        .search_misses = m.Counter(u64).init("fpindex_search_misses_total", .{}, opts),
-        .updates = m.Counter(u64).init("fpindex_updates_total", .{}, opts),
+        .searches = try IndexCounter.init(allocator, io, "fpindex_searches_total", .{}, opts),
+        .search_hits = try IndexCounter.init(allocator, io, "fpindex_search_hits_total", .{}, opts),
+        .search_misses = try IndexCounter.init(allocator, io, "fpindex_search_misses_total", .{}, opts),
+        .updates = try IndexCounter.init(allocator, io, "fpindex_updates_total", .{}, opts),
         .checkpoints = m.Counter(u64).init("fpindex_checkpoints_total", .{}, opts),
         .memory_merges = m.Counter(u64).init("fpindex_memory_merges_total", .{}, opts),
         .file_merges = m.Counter(u64).init("fpindex_file_merges_total", .{}, opts),
-        .search_duration = SearchDuration.init("fpindex_search_duration_seconds", .{}, opts),
+        .search_duration = try SearchDuration.init(allocator, io, "fpindex_search_duration_seconds", .{}, opts),
         .scanned_docs_per_hash = ScannedDocs.init("fpindex_scanned_docs_per_hash", .{}, opts),
         .scanned_blocks_per_hash = ScannedBlocks.init("fpindex_scanned_blocks_per_hash", .{}, opts),
         .docs = try IndexGauge.init(allocator, io, "fpindex_docs", .{ .help = "Number of documents in an index" }, opts),
@@ -51,22 +56,30 @@ pub fn init(allocator: std.mem.Allocator, io: std.Io, comptime opts: m.RegistryO
 }
 
 pub fn deinit() void {
+    metrics.searches.deinit();
+    metrics.search_hits.deinit();
+    metrics.search_misses.deinit();
+    metrics.updates.deinit();
+    metrics.search_duration.deinit();
     metrics.docs.deinit();
     metrics.version.deinit();
     metrics = m.initializeNoop(Metrics);
 }
 
-pub fn incSearches() void {
-    metrics.searches.incr();
+// The labelled increments can fail (first sight of a label allocates), but a
+// metrics allocation failure must not fail the search/update it measures, so
+// they swallow the error — the sample is dropped, the operation proceeds.
+pub fn incSearches(index_name: []const u8) void {
+    metrics.searches.incr(.{ .index = index_name }) catch {};
 }
-pub fn incSearchHit() void {
-    metrics.search_hits.incr();
+pub fn incSearchHit(index_name: []const u8) void {
+    metrics.search_hits.incr(.{ .index = index_name }) catch {};
 }
-pub fn incSearchMiss() void {
-    metrics.search_misses.incr();
+pub fn incSearchMiss(index_name: []const u8) void {
+    metrics.search_misses.incr(.{ .index = index_name }) catch {};
 }
-pub fn incUpdates() void {
-    metrics.updates.incr();
+pub fn incUpdates(index_name: []const u8) void {
+    metrics.updates.incr(.{ .index = index_name }) catch {};
 }
 pub fn incCheckpoints() void {
     metrics.checkpoints.incr();
@@ -77,8 +90,8 @@ pub fn incMemoryMerges() void {
 pub fn incFileMerges() void {
     metrics.file_merges.incr();
 }
-pub fn observeSearchSeconds(seconds: f64) void {
-    metrics.search_duration.observe(seconds);
+pub fn observeSearchSeconds(index_name: []const u8, seconds: f64) void {
+    metrics.search_duration.observe(.{ .index = index_name }, seconds) catch {};
 }
 pub fn observeScannedDocsPerHash(n: u64) void {
     metrics.scanned_docs_per_hash.observe(n);
@@ -94,10 +107,17 @@ pub fn setVersion(index_name: []const u8, v: u64) !void {
     try metrics.version.set(.{ .index = index_name }, v);
 }
 /// Drop all per-index series for a deleted index; without this the stale
-/// values would be scraped until restart.
+/// values would be scraped until restart. HistogramVec has no remove(), so a
+/// deleted index's search_duration series lingers frozen — harmless (its rate
+/// reads as zero), and a recreated index simply resumes it.
 pub fn removeIndex(index_name: []const u8) void {
-    metrics.docs.remove(.{ .index = index_name });
-    metrics.version.remove(.{ .index = index_name });
+    const labels: IndexLabels = .{ .index = index_name };
+    metrics.searches.remove(labels);
+    metrics.search_hits.remove(labels);
+    metrics.search_misses.remove(labels);
+    metrics.updates.remove(labels);
+    metrics.docs.remove(labels);
+    metrics.version.remove(labels);
 }
 
 /// Render all metrics in Prometheus text format. Callers who need the


### PR DESCRIPTION
Exports the upstream changelog position of each index as a new `fpindex_version{index="..."}` gauge, next to the existing `fpindex_docs`, and labels the request-level metrics per index.

**Per-index gauges as `GaugeVec`s** instead of hand-rendered Prometheus text:

- The scrape loop in `MultiIndex.writeMetrics` does a single pass, acquiring one reader per index and feeding both gauges from the same snapshot; the library handles sample grouping and label rendering.
- The series are removed when an index leaves the map (`dropIndex` and the `installBootstrap` swap-failure path), so no stale series outlive their index.
- `metrics.init` now takes an allocator and `std.Io` (needed by the labelled vecs) and moved from `main()` into `runServer`, after the zio runtime exists. Calls before init still hit the no-op registry.

**Request-level metrics labelled per index**: searches, hits/misses, updates, and search duration become `CounterVec`s / a `HistogramVec` keyed by index name — `MultiIndex` knows the name at all of these call sites. Global totals are recoverable as `sum(rate(...))`. The segment- and background-level metrics (scanned docs/blocks, checkpoints, merges) stay global; those layers do not know the index name.

Notes:

- The labelled increments swallow allocation errors — a metrics failure must not fail the operation it measures.
- `HistogramVec` has no `remove()`, so a deleted index's `search_duration` series stays frozen until restart; harmless (rate reads as zero), and a recreated index resumes it.
- The gauges are only ever written at scrape time under the manager lock, so they cannot drift from the real index state.