### PR TITLE
Match v2022 legacy search semantics

### DIFF
--- a/src/Index.zig
+++ b/src/Index.zig
@@ -1053,7 +1053,7 @@ test "allocation failure cannot leave the WAL ahead of published segments" {
     try std.testing.expect(saw_success);
 }
 
-test "duplicate query hashes score consistently across memory and file segments" {
+test "duplicate hashes score consistently across memory and file segments" {
     const rt = try zio.Runtime.init(std.testing.allocator, .{});
     defer rt.deinit();
 
@@ -1067,9 +1067,10 @@ test "duplicate query hashes score consistently across memory and file segments"
     var index = try Self.open(std.testing.allocator, dir, 1, true, null); // threshold 1 -> flushes
     defer index.deinit();
 
-    _ = try index.update(&[_]Change{.{ .insert = .{ .id = 1, .hashes = &[_]u32{ 100, 200 } } }}, .{});
+    _ = try index.update(&[_]Change{.{ .insert = .{ .id = 1, .hashes = &[_]u32{ 100, 100, 200 } } }}, .{});
 
-    // In-memory: a repeated query hash scores the doc once (query is a set).
+    // In-memory: repeated hashes in either the stored fingerprint or the query
+    // score the doc once (both are sets).
     {
         var r = SearchResults.init(std.testing.allocator, .{ .max_results = 10, .min_score = 1 });
         defer r.deinit();
@@ -1080,8 +1081,7 @@ test "duplicate query hashes score consistently across memory and file segments"
         try std.testing.expectEqual(@as(u32, 1), r.hits.get(1).?.score);
     }
 
-    // After flushing to a file segment the same query must score identically (it
-    // scored 2 before the dedupe, because FileSegment re-probed the repeated hash).
+    // After flushing to a file segment the same query must score identically.
     try index.runMaintenance();
     try std.testing.expectEqual(@as(usize, 1), index.segments.value.file.len);
     {

--- a/src/MemorySegment.zig
+++ b/src/MemorySegment.zig
@@ -138,6 +138,18 @@ pub fn build(self: *Self, changes: []const Change) !void {
 
     std.sort.pdq(Item, self.items.items, {}, Item.lessThan);
 
+    // A fingerprint is a set of hashes: retain one posting for each (hash, id)
+    // pair. Besides preserving set-based scoring, this keeps duplicate input
+    // hashes from inflating a fingerprint's score.
+    var out: usize = 0;
+    for (self.items.items) |item| {
+        if (out == 0 or Item.order(self.items.items[out - 1], item) != .eq) {
+            self.items.items[out] = item;
+            out += 1;
+        }
+    }
+    self.items.items.len = out;
+
     // Metadata is order-sensitive (last write wins), so apply it forward — unlike
     // the doc loop above, which runs in reverse for first-occurrence-wins on ids.
     for (changes) |change| {

--- a/src/common.zig
+++ b/src/common.zig
@@ -159,7 +159,13 @@ pub const SearchResults = struct {
             // Sorted by score descending, so nothing further can clear the bar.
             if (candidate.score < min_score) break;
             // Relative cutoff, anchored on the best score that actually survived.
-            if (out == 0) min_score = @max(min_score, candidate.score * self.options.min_score_pct / 100);
+            // Round to the nearest score rather than truncating toward zero.
+            // Use u64 so an untrusted percentage cannot overflow before the
+            // cutoff is clamped back to a score's u32 range.
+            if (out == 0) {
+                const relative = (50 + @as(u64, candidate.score) * self.options.min_score_pct) / 100;
+                min_score = @max(min_score, @as(u32, @intCast(@min(relative, std.math.maxInt(u32)))));
+            }
             self.results.items[out] = candidate;
             out += 1;
         }

--- a/src/legacy.zig
+++ b/src/legacy.zig
@@ -143,6 +143,13 @@ fn handleConnection(mi: *MultiIndex, stream: zio.net.Stream, index_name: []const
         idle.clear();
         const line = std.mem.trimEnd(u8, raw, "\r\n");
 
+        // Preserve the C++ listener's historical behavior: any line beginning
+        // with "quit" is acknowledged and then closes the connection.
+        if (std.mem.startsWith(u8, line, "quit")) {
+            reply(&writer.interface, "OK ", "") catch {};
+            return;
+        }
+
         _ = cmd_arena.reset(.retain_capacity);
         const resp = dispatch(mi, &session, cmd_arena.allocator(), line) catch |err| switch (err) {
             error.Canceled => return, // shutting down

--- a/tests/test_legacy.py
+++ b/tests/test_legacy.py
@@ -44,6 +44,12 @@ def test_unknown_command(legacy):
     assert legacy.cmd("frobnicate x").startswith("ERR ")
 
 
+def test_quit_acknowledges_and_closes_connection(legacy):
+    # v2022 accepted every command beginning with "quit", then closed.
+    assert legacy.cmd("quit now") == "OK "
+    assert legacy.f.readline() == b""
+
+
 def test_invalid_fingerprint(legacy):
     assert legacy.cmd("search notanumber").startswith("ERR ")
 
@@ -67,6 +73,17 @@ def test_insert_search_commit(legacy):
     # 1001 matches all three (score 3); 1002 matches 11000,12000 (score 2); desc.
     assert legacy.cmd("search 11000,12000,13000") == "OK 1001:3 1002:2"
     assert legacy.cmd("search 11000,12000,19000") == "OK 1002:3 1001:2"
+
+
+def test_top_score_percent_rounds_cutoff_like_v2022(legacy):
+    assert legacy.cmd("begin") == "OK "
+    assert legacy.cmd("insert 3001 31001,31002,31003") == "OK "
+    assert legacy.cmd("insert 3002 31001") == "OK "
+    assert legacy.cmd("commit") == "OK "
+
+    # v2022 rounds 3 * 50% to 2, excluding the score-1 result.
+    assert legacy.cmd("set top_score_percent 50") == "OK "
+    assert legacy.cmd("search 31001,31002,31003") == "OK 3001:3"
 
 
 def test_rollback_discards(legacy):


### PR DESCRIPTION
## What changed

- implement v2022-compatible `quit` acknowledgement and connection close behavior
- round the relative score threshold to the nearest score, matching the production C++ implementation
- deduplicate stored `(hash, fingerprint ID)` postings so repeated hashes do not inflate scores
- add legacy and pre/post-checkpoint regression coverage

## Why

The native legacy listener is intended to replace the production v2022 telnet API. These differences changed protocol behavior or search results for existing clients.

## Validation

- `zig build unit-tests` — 107 passed
- `zig build e2e-tests` — 50 passed