### PR TITLE
Route writes through std.Io.Writer, and stop losing errors on the way out

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -11,8 +11,8 @@
             .hash = "zio-0.17.0-xHbVVBnMJwAHQhkjFNfq2sAO_HTUz5F1awWWWX2psSNw",
         },
         .dusty = .{
-            .url = "git+https://github.com/lalinsky/dusty.git#81308672cf34236b2c60cbaac7deb616358d452c",
-            .hash = "dusty-0.1.0-Qdw7Rsf0HAB13L8HBDBsjp-gO5YNJ-grup-0ODXd9Dmo",
+            .url = "git+https://github.com/lalinsky/dusty.git#20fc42646a49d6461915bc069216e9e5dc9f5f1b",
+            .hash = "dusty-0.1.0-Qdw7Rlb9HAAgoTCgNH3-RQiljK-l1avjPmEDEjtdC8FT",
         },
         .msgpack = .{
             .url = "git+https://github.com/lalinsky/msgpack.zig.git#bef66711e678d42feba0e979dd7e6986d5c5ce13",

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -7,8 +7,8 @@
         // Pinned to each dep's main commit so the build is self-contained for CI
         // and fresh clones. Re-pin after landing changes upstream.
         .zio = .{
-            .url = "git+https://github.com/lalinsky/zio.git#e15178e5ca450c4804216fa5feba2fac5b757a46",
-            .hash = "zio-0.17.0-xHbVVAO_JwDO8z1Pxd-2W1DheL6b0S7bPtHSmG8ZITix",
+            .url = "git+https://github.com/lalinsky/zio.git#78bff089d6a163aa3f00492956840bd3bc80e1c1",
+            .hash = "zio-0.17.0-xHbVVBnMJwAHQhkjFNfq2sAO_HTUz5F1awWWWX2psSNw",
         },
         .dusty = .{
             .url = "git+https://github.com/lalinsky/dusty.git#81308672cf34236b2c60cbaac7deb616358d452c",

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -7,8 +7,8 @@
         // Pinned to each dep's main commit so the build is self-contained for CI
         // and fresh clones. Re-pin after landing changes upstream.
         .zio = .{
-            .url = "git+https://github.com/lalinsky/zio.git#a9f14d2deb2184e01a76b97ddd31b2353754c7b0",
-            .hash = "zio-0.15.0-xHbVVNRRIQDKB7pq7ZCKnjNGaT0GLtA7r6G3Tr30W3b5",
+            .url = "git+https://github.com/lalinsky/zio.git#e15178e5ca450c4804216fa5feba2fac5b757a46",
+            .hash = "zio-0.17.0-xHbVVAO_JwDO8z1Pxd-2W1DheL6b0S7bPtHSmG8ZITix",
         },
         .dusty = .{
             .url = "git+https://github.com/lalinsky/dusty.git#81308672cf34236b2c60cbaac7deb616358d452c",

--- a/src/FileSegment.zig
+++ b/src/FileSegment.zig
@@ -63,7 +63,11 @@ pub fn deinit(self: *Self) void {
     if (self.delete_on_destroy and self.data.len > 0) {
         var buf: [64]u8 = undefined;
         const name = std.fmt.bufPrint(&buf, "{x:0>16}-{x:0>8}.data", .{ self.info.commit_id, self.info.merges }) catch unreachable;
-        self.dir.deleteFile(name) catch |err| {
+        // Uncancelable: deinit has nowhere to report an error, so the unlink has to
+        // run even under cancellation — otherwise a merged-away file is orphaned with
+        // nothing left to retry it, and swallowing the cancel here would consume it
+        // for the whole task.
+        self.dir.deleteFileUncancelable(name) catch |err| {
             if (err != error.FileNotFound) log.warn("failed to delete segment file {s}: {}", .{ name, err });
         };
     }

--- a/src/Index.zig
+++ b/src/Index.zig
@@ -852,9 +852,18 @@ fn checkpoint(self: *Self, force: bool) !bool {
     // Transactions up to file_commit_id are now durable in file segments; drop the
     // oplog files entirely below it. (After the manifest commit, so a crash in
     // between just leaves redundant oplog entries that replay skips.)
-    self.oplog.truncate(self.file_commit_id) catch |err| {
-        log.warn("oplog truncate failed: {}", .{err});
-    };
+    //
+    // Shielded: the checkpoint is already committed, so this must run to completion
+    // rather than fail half-way under a shutdown cancel. Swallowing the error
+    // unshielded would also consume the task's pending cancellation and leave the
+    // checkpoint loop unable to observe it at its next suspension point.
+    {
+        zio.beginShield();
+        defer zio.endShield();
+        self.oplog.truncate(self.file_commit_id) catch |err| {
+            log.warn("oplog truncate failed: {}", .{err});
+        };
+    }
 
     metrics.incCheckpoints();
     log.info("checkpointed to file segment {x}-{x} ({} items)", .{ info.commit_id, info.merges, fseg.value.num_items });
@@ -967,10 +976,8 @@ fn mergeToFileSegment(self: *Self, comptime Segment: type, sources: []SharedPtr(
 
     try filefmt.writeSegment(self.data_dir, &merger, self.allocator);
     errdefer {
-        // Shielded so the just-written file is removed even under cancellation
-        // (a cancelled task's I/O is otherwise skipped, orphaning the file).
-        zio.beginShield();
-        defer zio.endShield();
+        // deleteSegmentFile is uncancelable, so the just-written file is removed even
+        // under cancellation (a cancelled task's I/O is otherwise skipped).
         filefmt.deleteSegmentFile(self.data_dir, info) catch |err| {
             log.warn("failed to remove segment file after error: {}", .{err});
         };

--- a/src/Index.zig
+++ b/src/Index.zig
@@ -986,7 +986,7 @@ fn writeManifestFor(self: *Self, file: []const FileRef) !void {
     const infos = try self.allocator.alloc(SegmentInfo, file.len);
     defer self.allocator.free(infos);
     for (file, 0..) |seg, i| infos[i] = seg.value.info;
-    try manifest.write(self.data_dir, self.allocator, infos);
+    try manifest.write(self.data_dir, infos);
 }
 
 fn cleanupTestDir(cwd: zio.Dir, path: []const u8) void {

--- a/src/MultiIndex.zig
+++ b/src/MultiIndex.zig
@@ -554,8 +554,8 @@ fn installNewLineage(self: *Self, name: []const u8, generation: u64) !*IndexRef 
 
 // Write the redirect and open (creating) the generation's v<gen> data dir. The
 // returned dir has its own fd, so the caller may close name_dir afterward.
-fn createLineageDir(self: *Self, name_dir: zio.Dir, name: []const u8, generation: u64) !zio.Dir {
-    try index_redirect.write(name_dir, self.allocator, .{ .name = name, .generation = generation, .deleted = false });
+fn createLineageDir(_: *Self, name_dir: zio.Dir, name: []const u8, generation: u64) !zio.Dir {
+    try index_redirect.write(name_dir, .{ .name = name, .generation = generation, .deleted = false });
     var buf: [index_redirect.max_data_dir_len]u8 = undefined;
     const dd = (index_redirect.IndexRedirect{ .name = name, .generation = generation }).dataDir(&buf);
     return openOrCreateDir(name_dir, dd);
@@ -872,7 +872,7 @@ fn deleteIndexReplicated(self: *Self, repl: *Replicator, name: []const u8, reque
 fn markDeleted(self: *Self, name: []const u8, generation: u64) !void {
     const name_dir = try self.dir.openDir(name, .{ .iterate = true });
     defer name_dir.close();
-    try index_redirect.write(name_dir, self.allocator, .{ .name = name, .generation = generation, .deleted = true });
+    try index_redirect.write(name_dir, .{ .name = name, .generation = generation, .deleted = true });
     var buf: [index_redirect.max_data_dir_len]u8 = undefined;
     const dd = (index_redirect.IndexRedirect{ .name = name, .generation = generation }).dataDir(&buf);
     deleteDirTree(self.allocator, name_dir, dd) catch |err| {

--- a/src/MultiIndex.zig
+++ b/src/MultiIndex.zig
@@ -615,7 +615,10 @@ pub fn bootstrapLineage(self: *Self, name: []const u8, generation: u64, reader: 
 
     const name_dir = try self.dir.openDir(name, .{ .iterate = true });
     defer name_dir.close();
-    const redirect = index_redirect.read(name_dir, self.allocator) catch return error.IndexNotFound;
+    const redirect = index_redirect.read(name_dir, self.allocator) catch |err| switch (err) {
+        error.Canceled => return error.Canceled,
+        else => return error.IndexNotFound,
+    };
     defer self.allocator.free(redirect.name);
     if (redirect.deleted or redirect.generation != generation) return error.IndexGenerationMismatch;
 
@@ -683,7 +686,10 @@ fn disarmTransferDeadline(transfer_deadline: ?*zio.AutoCancel) !void {
 pub fn bootstrapLineageFromSource(self: *Self, name: []const u8, generation: u64, stream: *BootstrapStream, transfer_deadline: ?*zio.AutoCancel) !u64 {
     const name_dir = try self.dir.openDir(name, .{ .iterate = true });
     defer name_dir.close();
-    const redirect = index_redirect.read(name_dir, self.allocator) catch return error.IndexNotFound;
+    const redirect = index_redirect.read(name_dir, self.allocator) catch |err| switch (err) {
+        error.Canceled => return error.Canceled,
+        else => return error.IndexNotFound,
+    };
     defer self.allocator.free(redirect.name);
     if (redirect.deleted or redirect.generation != generation) return error.IndexGenerationMismatch;
 
@@ -841,9 +847,17 @@ fn dropIndex(self: *Self, name: []const u8) !DropResult {
     metrics.removeIndex(name);
     // Mark the redirect deleted and drop the generation's data dir; keep
     // data/<name>/ + current so a recreate can bump to the next generation.
-    self.markDeleted(name, gen) catch |err| {
-        log.warn("failed to mark index '{s}' deleted: {}", .{ name, err });
-    };
+    //
+    // Shielded: the index is already out of the map, so the on-disk state has to
+    // catch up regardless of a shutdown cancel. Swallowing the error unshielded
+    // would also consume the task's pending cancellation.
+    {
+        zio.beginShield();
+        defer zio.endShield();
+        self.markDeleted(name, gen) catch |err| {
+            log.warn("failed to mark index '{s}' deleted: {}", .{ name, err });
+        };
+    }
     return .dropped;
 }
 

--- a/src/Oplog.zig
+++ b/src/Oplog.zig
@@ -312,12 +312,20 @@ pub fn truncate(self: *Self, commit_id: u64) !void {
     if (keep_from > 0) keep_from -= 1;
 
     var deleted: usize = 0;
+    // A cancel stops the loop like any other failure, but must not skip the
+    // bookkeeping below: the files already unlinked have to leave `self.files`
+    // either way. Reported after the list is fixed up.
+    var canceled = false;
     while (deleted < keep_from) : (deleted += 1) {
         const start = self.files.items[deleted];
         if (self.current_file != null and start == self.current_start) break; // never delete the open file
         var name_buf: [file_name_len]u8 = undefined;
         const name = buildName(&name_buf, start);
         self.dir.deleteFile(name) catch |err| {
+            if (err == error.Canceled) {
+                canceled = true;
+                break;
+            }
             if (err != error.FileNotFound) {
                 log.warn("failed to delete oplog file {s}: {}", .{ name, err });
                 break;
@@ -330,4 +338,5 @@ pub fn truncate(self: *Self, commit_id: u64) !void {
         self.files.shrinkRetainingCapacity(remaining);
         log.info("truncated {d} oplog files below commit {d}", .{ deleted, commit_id });
     }
+    if (canceled) return error.Canceled;
 }

--- a/src/Oplog.zig
+++ b/src/Oplog.zig
@@ -150,7 +150,11 @@ fn replay(self: *Self, ctx: anytype, handler: anytype) !void {
         var reader = file.reader(&read_buf);
         while (true) {
             _ = arena.reset(.retain_capacity);
-            switch (try readRecord(&reader.interface, arena.allocator())) {
+            const record = readRecord(&reader.interface, arena.allocator()) catch |err| switch (err) {
+                error.ReadFailed => return reader.err orelse error.Unexpected,
+                else => |e| return e,
+            };
+            switch (record) {
                 .record => |txn| {
                     const expected_commit_id = if (count == 0) start else self.last_commit_id + 1;
                     if (txn.id != expected_commit_id) return error.CorruptOplog;

--- a/src/coordinator_server.zig
+++ b/src/coordinator_server.zig
@@ -68,22 +68,20 @@ fn handleBootstrap(co: *Service, req: *http.Request, res: *http.Response) !void 
     var buf: [64 * 1024]u8 = undefined;
     var body = try res.stream(&buf);
 
-    // Encoded straight into the body: the writer buffers, so nothing needs the
-    // whole value contiguous first. Chunk boundaries fall wherever the buffer
-    // fills rather than on value edges, which the client does not care about --
-    // it decodes from a stream reader, not a chunk at a time.
-    try msgpack.encode(changelog_mod.BootstrapHeader{ .position = stream.position }, &body.interface);
-
-    while (try stream.next()) |changes| {
-        if (changes.len == 0) continue; // the empty array is the terminator, nothing else
-        try msgpack.encode(changes, &body.interface);
-    }
-    try msgpack.encode(@as([]const Change, &.{}), &body.interface);
-
-    // Only on the success path: an error above returns without the terminator,
-    // which is exactly the truncation signal the comment above promises. A value
-    // left half-written by such an error is part of that same truncation.
+    writeBootstrapBody(&body.interface, &stream) catch |err| switch (err) {
+        error.WriteFailed => return body.err orelse error.Unexpected,
+        else => |e| return e,
+    };
     try body.end();
+}
+
+fn writeBootstrapBody(w: *std.Io.Writer, stream: *changelog_mod.BootstrapStream) !void {
+    try msgpack.encode(changelog_mod.BootstrapHeader{ .position = stream.position }, w);
+    while (try stream.next()) |changes| {
+        if (changes.len == 0) continue;
+        try msgpack.encode(changes, w);
+    }
+    try msgpack.encode(@as([]const Change, &.{}), w);
 }
 
 fn handleTruncate(co: *Service, req: *http.Request, res: *http.Response) !void {
@@ -158,7 +156,10 @@ fn queryInt(req: *http.Request, name: []const u8) ?u64 {
 
 fn respond(value: anytype, res: *http.Response) !void {
     var body = res.writer();
-    try msgpack.encode(value, &body.interface);
+    msgpack.encode(value, &body.interface) catch |err| switch (err) {
+        error.WriteFailed => return body.err orelse error.Unexpected,
+        else => |e| return e,
+    };
     try body.end();
     try res.header("Content-Type", comptime http.ContentType.msgpack.toContentType());
 }

--- a/src/filefmt.zig
+++ b/src/filefmt.zig
@@ -8,10 +8,6 @@
 //                 by one empty block (num_items == 0) for SIMD read padding
 //   6. Block index - little-endian u32 max_hash per block
 //   7. Footer   - msgpack: magic, num_items, num_blocks, checksum
-//   8. Footer size - little-endian u32
-//
-// Written whole from an in-memory buffer via zio.File (atomic temp+rename), and
-// read whole into an aligned heap buffer (mlock'd anonymous memory comes later).
 
 const std = @import("std");
 const zio = @import("zio");
@@ -86,12 +82,10 @@ pub const SegmentFileFooter = struct {
     }
 };
 
-const WriteBlocksResult = struct {
-    footer: SegmentFileFooter,
-    max_hashes: []u32,
-};
-
-fn writeBlocks(seg_reader: anytype, writer: *std.Io.Writer, min_doc_id: u32, comptime block_size: u32, allocator: std.mem.Allocator) !WriteBlocksResult {
+/// Write the block section followed by the block index (one u32 max hash per
+/// block). `allocator` only backs the block index, which cannot be emitted
+/// until every block has been encoded.
+fn writeBlocks(seg_reader: anytype, writer: *std.Io.Writer, min_doc_id: u32, comptime block_size: u32, allocator: std.mem.Allocator) !SegmentFileFooter {
     var encoder = BlockEncoder.init();
     var items_buffer: [block.MAX_ITEMS_PER_BLOCK]Item = undefined;
     var items_in_buffer: usize = 0;
@@ -100,7 +94,7 @@ fn writeBlocks(seg_reader: anytype, writer: *std.Io.Writer, min_doc_id: u32, com
     var crc = std.hash.crc.Crc64Xz.init();
     var block_data: [block_size]u8 = undefined;
     var max_hashes: std.ArrayListUnmanaged(u32) = .empty;
-    errdefer max_hashes.deinit(allocator);
+    defer max_hashes.deinit(allocator);
 
     while (true) {
         while (items_in_buffer < items_buffer.len) {
@@ -126,14 +120,15 @@ fn writeBlocks(seg_reader: anytype, writer: *std.Io.Writer, min_doc_id: u32, com
         items_in_buffer = remaining;
     }
 
+    for (max_hashes.items) |max_hash| {
+        try writer.writeInt(u32, max_hash, .little);
+    }
+
     return .{
-        .footer = .{
-            .magic = footer_magic,
-            .num_items = num_items,
-            .num_blocks = num_blocks,
-            .checksum = crc.final(),
-        },
-        .max_hashes = try max_hashes.toOwnedSlice(allocator),
+        .magic = footer_magic,
+        .num_items = num_items,
+        .num_blocks = num_blocks,
+        .checksum = crc.final(),
     };
 }
 
@@ -147,62 +142,49 @@ pub fn writeSegment(dir: zio.Dir, seg_reader: anytype, allocator: std.mem.Alloca
     var name_buf: [max_file_name_size]u8 = undefined;
     const name = buildSegmentFileName(&name_buf, segment.info);
 
-    var w = std.Io.Writer.Allocating.init(allocator);
-    defer w.deinit();
-    const writer = &w.writer;
-    const packer = msgpack.packer(writer);
+    var file = try dir.createAtomicFile(name, .{});
+    defer file.deinit();
 
-    try packer.write(SegmentFileHeader{
-        .magic = header_magic,
-        .info = segment.info,
-        .has_metadata = true,
-        .has_docs = true,
-        .block_size = block_size,
-    });
-    try packer.writeMap(segment.metadata.entries);
-    try packer.writeMap(segment.docs);
+    var buf: [block_size * 16]u8 = undefined;
+    var fw = file.file.writer(&buf);
+    const w = &fw.interface;
+    const packer = msgpack.packer(w);
 
-    const rem = w.written().len % block_size;
-    if (rem != 0) try writer.splatByteAll(0, block_size - rem);
+    // std.Io.Writer collapses every failure into error.WriteFailed; we hold the
+    // FileWriter, so translate it back to the real errno rather than leak it.
+    const result = write: {
+        packer.write(SegmentFileHeader{
+            .magic = header_magic,
+            .info = segment.info,
+            .has_metadata = true,
+            .has_docs = true,
+            .block_size = block_size,
+        }) catch |err| break :write err;
+        packer.writeMap(segment.metadata.entries) catch |err| break :write err;
+        packer.writeMap(segment.docs) catch |err| break :write err;
 
-    var arena = std.heap.ArenaAllocator.init(allocator);
-    defer arena.deinit();
-    const result = try writeBlocks(seg_reader, writer, segment.min_doc_id, block_size, arena.allocator());
+        // Pad to a block boundary. logicalPos() is the true file offset; the
+        // buffered length is not, since a drain writes the buffer plus whatever
+        // overflowed it and so leaves fw.position at an arbitrary place.
+        const rem = fw.logicalPos() % block_size;
+        if (rem != 0) w.splatByteAll(0, block_size - rem) catch |err| break :write err;
 
-    for (result.max_hashes) |max_hash| {
-        try writer.writeInt(u32, max_hash, .little);
-    }
+        const footer = writeBlocks(seg_reader, w, segment.min_doc_id, block_size, allocator) catch |err| break :write err;
+        packer.write(footer) catch |err| break :write err;
 
-    const footer_start = w.written().len;
-    try packer.write(result.footer);
-    const footer_size: u32 = @intCast(w.written().len - footer_start);
-    try writer.writeInt(u32, footer_size, .little);
+        w.flush() catch |err| break :write err;
+        break :write footer;
+    };
 
-    const bytes = w.written();
+    const footer = result catch |err| switch (err) {
+        error.WriteFailed => return fw.err orelse error.Unexpected,
+        else => |e| return e,
+    };
 
-    var tmp_buf: [max_file_name_size + 4]u8 = undefined;
-    const tmp_name = std.fmt.bufPrint(&tmp_buf, "{s}.tmp", .{name}) catch unreachable;
+    try file.file.sync(.{});
+    try file.replace();
 
-    const file = try dir.createFile(tmp_name, .{ .truncate = true });
-    {
-        errdefer {
-            file.close();
-            zio.beginShield();
-            defer zio.endShield();
-            dir.deleteFile(tmp_name) catch |err| {
-                log.warn("failed to remove temp segment file: {}", .{err});
-            };
-        }
-        var written: usize = 0;
-        while (written < bytes.len) {
-            written += try file.write(bytes[written..], written);
-        }
-        try file.sync(.{});
-    }
-    file.close();
-    try dir.rename(tmp_name, dir, name);
-
-    log.info("wrote segment {s} ({} blocks, {} items)", .{ name, result.footer.num_blocks, result.footer.num_items });
+    log.info("wrote segment {s} ({} blocks, {} items)", .{ name, footer.num_blocks, footer.num_items });
 }
 
 /// Read the segment file for `info` from `dir` into `segment` (heap-resident).

--- a/src/filefmt.zig
+++ b/src/filefmt.zig
@@ -266,10 +266,13 @@ pub fn readSegment(dir: zio.Dir, info: SegmentInfo, segment: *FileSegment) !void
     if (footer.checksum != crc.final()) return error.ChecksumMismatch;
 }
 
+/// Remove a segment file. Both callers are cleanup after a failed write, so the
+/// unlink is uncancelable: a cancellation that skipped it would orphan the file
+/// with nothing left to retry it.
 pub fn deleteSegmentFile(dir: zio.Dir, info: SegmentInfo) !void {
     var name_buf: [max_file_name_size]u8 = undefined;
     const name = buildSegmentFileName(&name_buf, info);
-    try dir.deleteFile(name);
+    try dir.deleteFileUncancelable(name);
 }
 
 test "segment round-trip: write, read, search" {

--- a/src/index_redirect.zig
+++ b/src/index_redirect.zig
@@ -62,12 +62,7 @@ pub fn read(dir: zio.Dir, allocator: std.mem.Allocator) !IndexRedirect {
 }
 
 /// Atomically replace the redirect (temp + rename).
-pub fn write(dir: zio.Dir, allocator: std.mem.Allocator, redirect: IndexRedirect) !void {
-    var w = std.Io.Writer.Allocating.init(allocator);
-    defer w.deinit();
-    try msgpack.encode(redirect, &w.writer);
-    const bytes = w.written();
-
+pub fn write(dir: zio.Dir, redirect: IndexRedirect) !void {
     const file = try dir.createFile(redirect_tmp, .{ .truncate = true });
     {
         errdefer {
@@ -78,10 +73,13 @@ pub fn write(dir: zio.Dir, allocator: std.mem.Allocator, redirect: IndexRedirect
                 log.warn("failed to remove temp redirect file: {}", .{err});
             };
         }
-        var written: usize = 0;
-        while (written < bytes.len) {
-            written += try file.write(bytes[written..], written);
-        }
+        var buf: [4096]u8 = undefined;
+        var fw = file.writer(&buf);
+        msgpack.encode(redirect, &fw.interface) catch |err| switch (err) {
+            error.WriteFailed => return fw.err orelse error.Unexpected,
+            else => |e| return e,
+        };
+        fw.interface.flush() catch return fw.err orelse error.Unexpected;
         try file.sync(.{});
     }
     file.close();
@@ -118,7 +116,7 @@ test "write/read round-trip" {
         cwd.deleteDir(dir_path) catch {};
     }
 
-    try write(dir, testing.allocator, .{ .name = "test.index", .generation = 123, .deleted = false });
+    try write(dir, .{ .name = "test.index", .generation = 123, .deleted = false });
     const r = try read(dir, testing.allocator);
     defer testing.allocator.free(r.name);
     try testing.expectEqualStrings("test.index", r.name);

--- a/src/index_redirect.zig
+++ b/src/index_redirect.zig
@@ -67,9 +67,7 @@ pub fn write(dir: zio.Dir, redirect: IndexRedirect) !void {
     {
         errdefer {
             file.close();
-            zio.beginShield();
-            defer zio.endShield();
-            dir.deleteFile(redirect_tmp) catch |err| {
+            dir.deleteFileUncancelable(redirect_tmp) catch |err| {
                 log.warn("failed to remove temp redirect file: {}", .{err});
             };
         }

--- a/src/manifest.zig
+++ b/src/manifest.zig
@@ -46,9 +46,7 @@ pub fn write(dir: zio.Dir, segments: []const SegmentInfo) !void {
     {
         errdefer {
             file.close();
-            zio.beginShield();
-            defer zio.endShield();
-            dir.deleteFile(manifest_tmp) catch |err| {
+            dir.deleteFileUncancelable(manifest_tmp) catch |err| {
                 log.warn("failed to remove temp manifest file: {}", .{err});
             };
         }

--- a/src/manifest.zig
+++ b/src/manifest.zig
@@ -41,12 +41,7 @@ pub fn read(dir: zio.Dir, allocator: std.mem.Allocator) ![]SegmentInfo {
 /// Atomically replace the manifest with `segments`. Nothing index-level is stored:
 /// whether the index is upstream-fed is derivable from the segments themselves (any
 /// non-null SegmentInfo.version), so there is no separate flag to keep in sync.
-pub fn write(dir: zio.Dir, allocator: std.mem.Allocator, segments: []const SegmentInfo) !void {
-    var w = std.Io.Writer.Allocating.init(allocator);
-    defer w.deinit();
-    try msgpack.encode(segments, &w.writer);
-    const bytes = w.written();
-
+pub fn write(dir: zio.Dir, segments: []const SegmentInfo) !void {
     const file = try dir.createFile(manifest_tmp, .{ .truncate = true });
     {
         errdefer {
@@ -57,10 +52,13 @@ pub fn write(dir: zio.Dir, allocator: std.mem.Allocator, segments: []const Segme
                 log.warn("failed to remove temp manifest file: {}", .{err});
             };
         }
-        var written: usize = 0;
-        while (written < bytes.len) {
-            written += try file.write(bytes[written..], written);
-        }
+        var buf: [4096]u8 = undefined;
+        var fw = file.writer(&buf);
+        msgpack.encode(segments, &fw.interface) catch |err| switch (err) {
+            error.WriteFailed => return fw.err orelse error.Unexpected,
+            else => |e| return e,
+        };
+        fw.interface.flush() catch return fw.err orelse error.Unexpected;
         try file.sync(.{});
     }
     file.close();

--- a/src/peers.zig
+++ b/src/peers.zig
@@ -71,6 +71,10 @@ pub fn resolve(self: Self, arena: std.mem.Allocator) ![]const []const u8 {
     var out: std.ArrayListUnmanaged([]const u8) = .empty;
     for (self.urls) |url| {
         self.expandUrl(arena, url, &out) catch |err| {
+            // A shutdown is not a resolution failure: resolution suspends, so
+            // swallowing the cancel here would both hide it and consume it,
+            // leaving the caller unable to observe it later.
+            if (err == error.Canceled) return error.Canceled;
             // One unresolvable name must not hide the peers that did resolve.
             log.warn("peer URL '{s}' did not resolve: {}", .{ url, err });
         };

--- a/src/server.zig
+++ b/src/server.zig
@@ -135,7 +135,10 @@ fn respond(value: anytype, req: *http.Request, res: *http.Response) !void {
         .json => try res.json(value, .{}),
         .msgpack => {
             var body = res.writer();
-            try msgpack.encode(value, &body.interface);
+            msgpack.encode(value, &body.interface) catch |err| switch (err) {
+                error.WriteFailed => return body.err orelse error.Unexpected,
+                else => |e| return e,
+            };
             try body.end();
             try res.header("Content-Type", comptime http.ContentType.msgpack.toContentType());
         },
@@ -163,7 +166,10 @@ fn optionalBody(comptime T: type, req: *http.Request, default: T) !T {
 
 fn handleMetrics(ctx: *ServerContext, _: *http.Request, res: *http.Response) !void {
     var body = res.writer();
-    try ctx.mi.writeMetrics(&body.interface);
+    ctx.mi.writeMetrics(&body.interface) catch |err| switch (err) {
+        error.WriteFailed => return body.err orelse error.Unexpected,
+        else => |e| return e,
+    };
     try body.end();
     try res.header("Content-Type", "text/plain; version=0.0.4; charset=utf-8");
 }
@@ -292,13 +298,8 @@ fn handleSnapshotExport(ctx: *ServerContext, req: *http.Request, res: *http.Resp
     var buf: [64 * 1024]u8 = undefined;
     var body = try res.stream(&buf);
     snapshot.writeSnapshot(&body.interface, req.arena, src.reader.snapshot.value, src.generation) catch |err| switch (err) {
-        error.WriteFailed => return body.err orelse error.WriteFailed,
-        else => return err,
+        error.WriteFailed => return body.err orelse error.Unexpected,
+        else => |e| return e,
     };
-    // Flushes what is left AND writes the chunked terminator. Without it the client
-    // waits on a body that never ends.
-    body.end() catch |err| switch (err) {
-        error.WriteFailed => return body.err orelse error.WriteFailed,
-        else => return err,
-    };
+    try body.end();
 }

--- a/src/snapshot.zig
+++ b/src/snapshot.zig
@@ -93,7 +93,7 @@ pub fn restoreInto(dir: zio.Dir, r: *std.Io.Reader, arena: std.mem.Allocator, ex
 
     const infos = try arena.alloc(SegmentInfo, header.segments.len);
     for (header.segments, 0..) |seg, i| infos[i] = seg.info;
-    try manifest.write(dir, arena, infos);
+    try manifest.write(dir, infos);
 
     const scratch = try arena.alloc(u8, 128 * 1024);
     for (header.segments) |seg| {


### PR DESCRIPTION
Eight commits, each building on its own. Two threads: send every write through a `std.Io.Writer` instead of buffering it whole, and fix the error handling that exposes.

## Streaming the writes

`manifest.write`, `index_redirect.write` and `filefmt.writeSegment` each built their whole output in a `std.Io.Writer.Allocating` and then wrote the bytes out. They now write through a fixed buffer directly to the file. For segments that matters: a merge was holding a second full copy of the segment on the heap at exactly the moment memory pressure is highest.

`writeSegment` also moves to `zio.AtomicFile`, replacing the hand-rolled tmp-name / errdefer-unlink / rename dance.

Two things fell out of the segment conversion:

- **Padding must use `fw.logicalPos()`, not the buffered length.** A drain writes the buffer *plus* whatever overflowed it, so `fw.position` is not block-aligned in general and the buffered length stops tracking the file offset once the header exceeds the buffer — about 1400 docs. Past that the block section landed at an offset `readSegment` does not compute, i.e. an unreadable segment.
- **`writeBlocks` now emits the block index itself** and returns the footer, so the arena and the owned `max_hashes` slice are gone. The trailing footer-size `u32` is dropped too — nothing ever read it, since `readSegment` locates the footer forward from the block index.

## Not losing the cause

`std.Io.Writer` collapses every failure into `error.WriteFailed` and parks the real errno on the writer. Several places `try`d straight through it and threw the cause away; those now unwrap to `fw.err` / `reader.err` / `body.err`.

## Not losing cancellation

`bootstrapLineage` and `bootstrapLineageFromSource` mapped *every* error from `index_redirect.read` to `IndexNotFound`, `Canceled` included. That is not merely lossy. zio tracks cancellation as `user_canceled` plus a `pending_errors` count, and the cancellation point that produced the error has already consumed the pending one — so discarding it leaves the task marked canceled with nothing pending, and every later suspension point blocks as if it were never canceled.

That is what wedged `a poison meta op parks and does not wedge other indexes`. The test body passed; teardown hung forever. `MultiIndex.deinit` cancelled the consumer for `good` while it sat in the seed path, the cancel came back out as `IndexNotFound`, the consumer retried, succeeded, and parked in an untimed `coordinator.read` that nothing could break. `JoinHandle.cancel` waited on it for good.

**The unit test suite had never reached the end.** It now runs 109/109 in about 7 seconds.

A sweep for the same shape found more, treated by what the site actually needs:

| Site | Treatment |
| --- | --- |
| `peers.resolve` | propagate — DNS suspends, and this is on the same bootstrap path |
| `Oplog.truncate` | stop the loop, still fix up `self.files`, then report |
| `Index.checkpoint` truncate, `MultiIndex.dropIndex` markDeleted | shielded — must finish once the caller has committed, and each wraps several ops |
| `FileSegment.deinit`, `deleteSegmentFile`, temp-file errdefers | `deleteFileUncancelable`, which also replaced two existing shield blocks |

The other two callers of `index_redirect.read` already had the right shape (`else => return err`), so both fixed sites now match them.

## Dependencies

- **zio** re-pinned to main for `createAtomicFile`, the `File.Writer` export, and the uncancelable deletes.
- **dusty** re-pinned for lalinsky/dusty#138, which makes `BodyWriter.end` / `StreamingBodyWriter.end` report the cause rather than `error.WriteFailed`. Without it the plain `try body.end()` at five call sites here would discard an ECONNRESET on the chunked terminator — the write most likely to find a peer that has gone away.

## Testing

`zig build unit-tests`: 109/109. Every one of the 8 commits builds individually, so `git bisect` works across the branch.