### PR TITLE
ci: pin the release binary's ISA to x86_64_v3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,8 +58,15 @@ jobs:
         with:
           version: 0.16.0
 
+      # -Dcpu pins the ISA. Without it the build targets the runner's native
+      # CPU, so the published binary carries whatever extensions GitHub's
+      # machine happened to have -- v26.8.0 shipped AVX-512 and died with
+      # SIGILL, before any logging, on every host without it. x86_64_v3 is
+      # AVX2/FMA/BMI2, i.e. Haswell and newer, which is the oldest hardware we
+      # support. `baseline` is not an option: it fails to compile in
+      # streamvbyte.zig.
       - name: Build release binary
-        run: zig build --release=fast --summary all
+        run: zig build --release=fast -Dcpu=x86_64_v3 --summary all
 
       - name: Log in to the Container registry
         if: github.event_name != 'pull_request'


### PR DESCRIPTION
The release binary is built with a bare `zig build --release=fast`, and `build.zig` uses `standardTargetOptions(.{})`, so it targets **the runner's native CPU**. The published artifact therefore carries whatever ISA extensions GitHub happened to allocate that day.

`v26.8.0` drew a runner with AVX-512. The result:

```
$ docker run --rm ghcr.io/acoustid/acoustid-index:v26.8.0
status=exited exit=132        # 128+4 = SIGILL
--- logs ---
(empty)

Program received signal SIGILL, Illegal instruction.
=> 0x127f2a1 <mem.eql__anon_2823+113>:  vpcmpneqb (%rdx),%xmm0,%k0
```

It dies inside `std.mem.eql` before any logging, so a user sees a restart loop with no output. It runs fine on the machine that built it, which is why CI was green.

This is not a code change — the older image referenced in #160 has **zero** AVX-512 references built from the same source tree. It is purely which runner drew the build, which also means the supported CPU set varies from release to release.

## The floor

`x86_64_v3` = AVX2, FMA, BMI1, BMI2, F16C, LZCNT, MOVBE — Haswell and newer, matching the oldest hardware we support (Xeon E5-1650 v3).

`-Dcpu=baseline` is not an option; it fails to compile:

```
src/streamvbyte.zig:55:26: error: vector index not comptime known
```

## Measurements

| | native (v26.8.0) | `x86_64_v3` |
| --- | --- | --- |
| AVX-512 refs (`%zmm`/`%k0-7`) | 4107 | **0** |
| VBMI/VNNI (`vpermi2b`, `vpdpwssd`) | 93 / 17 | **0** |
| AVX2 (`%ymm`) | — | 16074 |

The published binary also used `vpermi2b %zmm` (AVX512_VBMI) and EVEX `vpdpwssd` (AVX512_VNNI), so it required Ice Lake or newer — not merely "some AVX-512". A Skylake-W Xeon would fault on it too.

## Verification

Built the image from this flag and ran it:

- starts, `/_health` returns OK
- **also** starts with `io_uring_setup` forced to `EPERM` via a seccomp profile, exercising the epoll fallback that #160 needs

## Follow-ups, not in this PR

- `v26.8.0` and `latest` still point at the AVX-512 binary and need re-cutting once this lands.
- `-Dcpu=x86_64_v3` also drops AES-NI (654 `vaesenc` in the native build, 0 here), since AES is not part of any psABI level. Every CPU we support has it; `x86_64_v3+aes+pclmul` restores it, and matters if snapshot transfers ever run over TLS. Left out here to keep this to the crash fix.